### PR TITLE
[FEAT] AOP 적용 및 BaseEntity 도입 

### DIFF
--- a/src/main/java/com/wilo/server/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/wilo/server/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.wilo.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/wilo/server/global/entity/BaseEntity.java
+++ b/src/main/java/com/wilo/server/global/entity/BaseEntity.java
@@ -1,0 +1,39 @@
+package com.wilo.server.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        this.deletedAt = null;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/src/main/java/com/wilo/server/global/entity/BaseEntity.java
+++ b/src/main/java/com/wilo/server/global/entity/BaseEntity.java
@@ -16,10 +16,11 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 
     @Column


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #2 , #5 

## 📝 작업 내용

**1. AOP 기반 공통 로깅 도입**
- Controller 레이어에 API 실행 시간 측정 AOP 적용
- Service 레이어에 메서드 실행 흐름 로깅 AOP 적용

**2. 공통 BaseEntity 도입**
- 모든 JPA Entity에서 공통으로 사용하는 필드 추상화 진행 

**3. JPA Auditing 설정**
- @EnableJpaAuditing 활성화로 엔티티 생성/수정 시점 자동 관리 

**4. 글로벌 예외/응답 구조 기반 마련**
- ApplicationException + ErrorCase 구조 및 모든 API 응답을 CommonResponse로 통일


## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 브랜치 당연히 제꺼인줄 알고 커밋하다가 develop인걸 알아버려서 AOP는 바로 develop에 적용했는데 기초 코드라 문제는 없을것 같아서 바로 적용시키겠습니다 ㅎㅎ,, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * JPA 감사(생성/수정 시간) 기능이 애플리케이션 전반에서 활성화되었습니다.
  * 엔티티의 생성 및 수정 시간이 자동으로 기록됩니다.
  * 데이터 삭제 시 안전한 논리 삭제(soft-delete) 기능이 추가되었습니다.
  * 삭제된 데이터 복원 기능이 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->