### PR TITLE
[CHORE] Swagger, Redis config 설정 및 로컬개발용 docker 구성 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application.yml

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 application.yml
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,12 @@ dependencies {
 
 	// AOP
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: wilo-mysql
+    ports:
+      - "3307:3306"   # 다른 프로젝트랑 안겹치게 우선 로컬쪽은 3307로 설정
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: wilo
+      MYSQL_USER: wilo
+      MYSQL_PASSWORD: wilo1234
+      TZ: Asia/Seoul
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - wilo-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7.2
+    container_name: wilo-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - wilo-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  wilo-mysql-data:
+  wilo-redis-data:

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - wilo-mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p$${MYSQL_ROOT_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -7,10 +7,10 @@ services:
     ports:
       - "3307:3306"   # 다른 프로젝트랑 안겹치게 우선 로컬쪽은 3307로 설정
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: wilo
-      MYSQL_USER: wilo
-      MYSQL_PASSWORD: wilo1234
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       TZ: Asia/Seoul
     command:
       - --character-set-server=utf8mb4

--- a/src/main/java/com/wilo/server/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/wilo/server/global/config/redis/RedisConfig.java
@@ -1,0 +1,64 @@
+package com.wilo.server.global.config.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config =
+                new RedisStandaloneConfiguration(host, port);
+
+        if (StringUtils.hasText(password)) {
+            config.setPassword(RedisPassword.of(password));
+        }
+
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+}

--- a/src/main/java/com/wilo/server/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/wilo/server/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.wilo.server.global.config.swagger;
+
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String JWT_SCHEME_NAME = "JWT";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(new Info()
+                        .title("Wilo API")
+                        .description("Wilo 백엔드 API 명세서")
+                        .version("v1.0.0"))
+                .addSecurityItem(
+                        new SecurityRequirement().addList(JWT_SCHEME_NAME)
+                )
+                .components(
+                        new Components().addSecuritySchemes(
+                                JWT_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(JWT_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=wilo

--- a/src/test/java/com/wilo/server/WiloApplicationTests.java
+++ b/src/test/java/com/wilo/server/WiloApplicationTests.java
@@ -2,8 +2,10 @@ package com.wilo.server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class WiloApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,34 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:wilo-test;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  h2:
+    console:
+      enabled: false
+
+logging:
+  level:
+    root: warn
+
+jwt:
+  secret: ${JWT_SECRET:wilo-test-jwt-secret-32-bytes-required-for-validation}
+  access-exp: 3600000
+  refresh-exp: 1209600000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -19,6 +19,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+      repositories:
+        enabled: false
 
   h2:
     console:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #3, #4 

## 📝 작업 내용

1. 로컬 개발 환경 Docker 구성
- MySQL / Redis 로컬 개발용 Docker Compose 구성
- 프로젝트 간 충돌 방지를 위해 MySQL 포트를 3307로 분리
- Healthcheck 추가


2. Spring 환경별 설정 분리
- application.yml : 공통 설정
- application-test.yml : 테스트 전용 환경



## 🖼️ 스크린샷 (선택)
### 도커 컨테이너 확인 완료
<img width="1826" height="357" alt="도커구성" src="https://github.com/user-attachments/assets/c09cce9d-5bc4-4ec4-b475-5d9330c3ff67" />


## 💬 리뷰 요구사항 (선택)

> application.yml과 .env 파일 내용 노션 설정정보에 업데이트 해놨습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Swagger/OpenAPI UI로 API 문서화 제공 (JWT 인증 연동)
  * Redis 기반 캐싱/데이터 지원 추가

* **Chores**
  * 로컬 개발용 Docker Compose 구성 추가(MySQL·Redis 포함, 데이터 볼륨 및 헬스체크 설정)

* **Tests**
  * 테스트 전용 프로파일 및 테스트용 설정(H2 인메모리 DB 등) 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->