### PR TITLE
[FEAT] 챗봇 유형 조회 및 세션 생성 API 구현

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -1,0 +1,38 @@
+package com.wilo.server.chatbot.controller;
+
+import com.wilo.server.chatbot.dto.ChatSessionCreateRequest;
+import com.wilo.server.chatbot.dto.ChatSessionCreateResponse;
+import com.wilo.server.chatbot.service.ChatSessionService;
+import com.wilo.server.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat/sessions")
+public class ChatSessionController {
+
+    private final ChatSessionService chatSessionService;
+
+    @PostMapping
+    @Operation(
+            summary = "새 대화 시작(세션 생성)",
+            description = "채팅 대화 세션을 생성합니다. 로그인 사용자는 user_id로, 비로그인 사용자는 guestId(UUID)로 세션을 생성합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "세션 생성 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 챗봇 유형", content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatSessionCreateResponse> createSession(
+            @Valid @RequestBody ChatSessionCreateRequest request
+    ) {
+        return CommonResponse.success(chatSessionService.createSession(request));
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -5,6 +5,7 @@ import com.wilo.server.chatbot.dto.ChatSessionCreateResponse;
 import com.wilo.server.chatbot.service.ChatSessionService;
 import com.wilo.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -23,16 +25,22 @@ public class ChatSessionController {
     @PostMapping
     @Operation(
             summary = "새 대화 시작(세션 생성)",
-            description = "채팅 대화 세션을 생성합니다. 로그인 사용자는 user_id로, 비로그인 사용자는 guestId(UUID)로 세션을 생성합니다."
+            description = "채팅 대화 세션을 생성합니다. 로그인 사용자는 user_id로, 비로그인 사용자는 X-Guest-Id로 세션을 생성합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "세션 생성 성공"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 챗봇 유형", content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+            @ApiResponse(responseCode = "400", description = "게스트 헤더 누락/요청값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 챗봇 유형",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<ChatSessionCreateResponse> createSession(
+            @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
             @Valid @RequestBody ChatSessionCreateRequest request
     ) {
-        return CommonResponse.success(chatSessionService.createSession(request));
+        return CommonResponse.success(chatSessionService.createSession(request, guestId));
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatbotTypeController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatbotTypeController.java
@@ -1,0 +1,35 @@
+package com.wilo.server.chatbot.controller;
+
+import com.wilo.server.chatbot.dto.ChatbotTypeListResponse;
+import com.wilo.server.chatbot.service.ChatbotTypeService;
+import com.wilo.server.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chatbot-types")
+public class ChatbotTypeController {
+
+    private final ChatbotTypeService chatbotTypeService;
+
+    @GetMapping
+    @Operation(
+            summary = "챗봇 유형 목록 조회",
+            description = "온보딩 및 설정 화면에서 사용되는 챗봇 유형 목록을 조회합니다. (비로그인 허용)"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatbotTypeListResponse> getChatbotTypes() {
+        return CommonResponse.success(chatbotTypeService.getChatbotTypes());
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionCreateRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionCreateRequest.java
@@ -8,7 +8,4 @@ public class ChatSessionCreateRequest {
 
     @NotNull(message = "chatbotTypeId는 필수입니다.")
     private Long chatbotTypeId;
-
-    // 비로그인 사용자를 위한 식별자(없으면 서버가 생성해서 내려줌)
-    private String guestId;
 }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionCreateRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionCreateRequest.java
@@ -1,0 +1,14 @@
+package com.wilo.server.chatbot.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ChatSessionCreateRequest {
+
+    @NotNull(message = "chatbotTypeId는 필수입니다.")
+    private Long chatbotTypeId;
+
+    // 비로그인 사용자를 위한 식별자(없으면 서버가 생성해서 내려줌)
+    private String guestId;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionCreateResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionCreateResponse.java
@@ -1,0 +1,29 @@
+package com.wilo.server.chatbot.dto;
+
+
+import com.wilo.server.chatbot.entity.ChatSession;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatSessionCreateResponse {
+
+    private Long sessionId;
+    private Long chatbotTypeId;
+    private String title;
+    private String status;
+
+    // 비로그인일 때만 내려주기
+    private String guestId;
+
+    public static ChatSessionCreateResponse from(ChatSession session) {
+        return ChatSessionCreateResponse.builder()
+                .sessionId(session.getId())
+                .chatbotTypeId(session.getChatbotType().getId())
+                .title(session.getTitle())
+                .status(session.getStatus().name())
+                .guestId(session.getGuestId())
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeItem.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeItem.java
@@ -1,0 +1,26 @@
+package com.wilo.server.chatbot.dto;
+
+import com.wilo.server.chatbot.entity.ChatbotType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatbotTypeItem {
+
+    private Long id;
+    private String code;
+    private String name;
+    private String description;
+    private boolean isActive;
+
+    public static ChatbotTypeItem from(ChatbotType type) {
+        return ChatbotTypeItem.builder()
+                .id(type.getId())
+                .code(type.getCode())
+                .name(type.getName())
+                .description(type.getDescription())
+                .isActive(type.isActive())
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeListResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeListResponse.java
@@ -1,0 +1,19 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatbotTypeListResponse {
+
+    private List<ChatbotTypeItem> chatbotTypes;
+
+    public static ChatbotTypeListResponse of(List<ChatbotTypeItem> items) {
+        return ChatbotTypeListResponse.builder()
+                .chatbotTypes(items)
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -1,0 +1,63 @@
+package com.wilo.server.chatbot.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "chat_sessions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 로그인 사용자면 user_id 세팅
+    @Column(name = "user_id")
+    private Long userId;
+
+    // 게스트면 guest_id 세팅
+    @Column(name = "guest_id", length = 100)
+    private String guestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatbot_type_id", nullable = false)
+    private ChatbotType chatbotType;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ChatSessionStatus status;
+
+    @Column(name = "last_message_at")
+    private LocalDateTime lastMessageAt;
+
+    public static ChatSession createForUser(Long userId, ChatbotType chatbotType) {
+        ChatSession session = new ChatSession();
+        session.userId = userId;
+        session.guestId = null;
+        session.chatbotType = chatbotType;
+        session.title = "새로운 대화";
+        session.status = ChatSessionStatus.ACTIVE;
+        session.lastMessageAt = null;
+        return session;
+    }
+
+    public static ChatSession createForGuest(String guestId, ChatbotType chatbotType) {
+        ChatSession session = new ChatSession();
+        session.userId = null;
+        session.guestId = guestId;
+        session.chatbotType = chatbotType;
+        session.title = "새로운 대화";
+        session.status = ChatSessionStatus.ACTIVE;
+        session.lastMessageAt = null;
+        return session;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSessionStatus.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSessionStatus.java
@@ -1,0 +1,5 @@
+package com.wilo.server.chatbot.entity;
+
+public enum ChatSessionStatus {
+    ACTIVE, ARCHIVED, DELETED
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatbotType.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatbotType.java
@@ -1,0 +1,29 @@
+package com.wilo.server.chatbot.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chatbot_types")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatbotType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+}

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -8,8 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatbotErrorCase implements ErrorCase {
 
-    CHATBOT_INTERNAL_SERVER_ERROR(500, 3500, "서버 오류가 발생했습니다."),
-    CHATBOT_TYPE_NOT_FOUND(404, 3002, "존재하지 않는 챗봇 유형입니다.");
+    CHATBOT_INTERNAL_SERVER_ERROR(500, 3001, "서버 오류가 발생했습니다."),
+    CHATBOT_TYPE_NOT_FOUND(404, 3002, "존재하지 않는 챗봇 유형입니다."),
+    GUEST_ID_REQUIRED(400, 3003, "비로그인 사용자는 X-Guest-Id 헤더가 필요합니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -1,0 +1,16 @@
+package com.wilo.server.chatbot.exception;
+
+import com.wilo.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatbotErrorCase implements ErrorCase {
+
+    CHATBOT_INTERNAL_SERVER_ERROR(500, 3500, "서버 오류가 발생했습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String message;
+}

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatbotErrorCase implements ErrorCase {
 
-    CHATBOT_INTERNAL_SERVER_ERROR(500, 3500, "서버 오류가 발생했습니다.");
+    CHATBOT_INTERNAL_SERVER_ERROR(500, 3500, "서버 오류가 발생했습니다."),
+    CHATBOT_TYPE_NOT_FOUND(404, 3002, "존재하지 않는 챗봇 유형입니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
@@ -1,0 +1,7 @@
+package com.wilo.server.chatbot.repository;
+
+import com.wilo.server.chatbot.entity.ChatSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+}

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatbotTypeRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatbotTypeRepository.java
@@ -1,0 +1,11 @@
+package com.wilo.server.chatbot.repository;
+
+import com.wilo.server.chatbot.entity.ChatbotType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatbotTypeRepository extends JpaRepository<ChatbotType, Long> {
+
+    List<ChatbotType> findAllByIsActiveTrueOrderByIdAsc();
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -1,0 +1,58 @@
+package com.wilo.server.chatbot.service;
+
+import com.wilo.server.chatbot.dto.ChatSessionCreateRequest;
+import com.wilo.server.chatbot.dto.ChatSessionCreateResponse;
+import com.wilo.server.chatbot.entity.ChatSession;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatSessionRepository;
+import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatSessionService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatbotTypeRepository chatbotTypeRepository;
+
+    public ChatSessionCreateResponse createSession(ChatSessionCreateRequest request) {
+
+        Long userId = extractUserIdIfAuthenticated();
+
+        var chatbotType = chatbotTypeRepository.findById(request.getChatbotTypeId())
+                .filter(type -> type.isActive())
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.CHATBOT_TYPE_NOT_FOUND));
+
+        ChatSession session;
+
+        if (userId != null) {
+            session = ChatSession.createForUser(userId, chatbotType);
+        } else {
+            String guestId = (request.getGuestId() == null || request.getGuestId().isBlank())
+                    ? UUID.randomUUID().toString()
+                    : request.getGuestId();
+
+            session = ChatSession.createForGuest(guestId, chatbotType);
+        }
+
+        ChatSession saved = chatSessionRepository.save(session);
+        return ChatSessionCreateResponse.from(saved);
+    }
+
+    private Long extractUserIdIfAuthenticated() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) { return null; }
+
+        if (auth.getPrincipal() instanceof Long userId) {
+            return userId;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -12,7 +12,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/wilo/server/chatbot/service/ChatbotTypeService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatbotTypeService.java
@@ -1,0 +1,35 @@
+package com.wilo.server.chatbot.service;
+
+import com.wilo.server.chatbot.dto.ChatbotTypeItem;
+import com.wilo.server.chatbot.dto.ChatbotTypeListResponse;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatbotTypeService {
+
+    private final ChatbotTypeRepository chatbotTypeRepository;
+
+    public ChatbotTypeListResponse getChatbotTypes() {
+        try {
+            List<ChatbotTypeItem> items = chatbotTypeRepository
+                    .findAllByIsActiveTrueOrderByIdAsc()
+                    .stream()
+                    .map(ChatbotTypeItem::from)
+                    .toList();
+
+            return ChatbotTypeListResponse.of(items);
+
+        } catch (Exception e) {
+            throw new ApplicationException(ChatbotErrorCase.CHATBOT_INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/src/main/java/com/wilo/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/wilo/server/global/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                                 .requestMatchers("/", "/robots.txt", "/home","/images/**", "/login", "/css/**", "/js/**", "/swagger-ui/**", "/v3/api-docs/**", "/actuator/**").permitAll()
                                 .requestMatchers("/api/auth/**").permitAll()
                                 .requestMatchers("/api/v1/chatbot-types/**").permitAll()
+                                .requestMatchers("/api/v1/chat/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .logout(logout -> logout

--- a/src/main/java/com/wilo/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/wilo/server/global/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                         authorizeRequests
                                 .requestMatchers("/", "/robots.txt", "/home","/images/**", "/login", "/css/**", "/js/**", "/swagger-ui/**", "/v3/api-docs/**", "/actuator/**").permitAll()
                                 .requestMatchers("/api/auth/**").permitAll()
+                                .requestMatchers("/api/v1/chatbot-types/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .logout(logout -> logout


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #14 

## 📝 작업 내용

**1. 챗봇 유형 목록 조회 API 구현**
- `GET /api/v1/chatbot-types`
- 활성화된 챗봇 유형 목록 반환
- 온보딩/설정 화면에서 사용

**2. 새 대화 시작(세션 생성) API 구현**

- `POST /api/v1/chat/sessions`
- 로그인 사용자: JWT 기반 userId 사용
- 비로그인 사용자: `X-Guest-Id` 헤더 기반 세션 생성



## 🖼️ 스크린샷 (선택)
### 챗봇 유형 목록 조회 성공
<img width="1463" height="945" alt="챗봇유형조회성공" src="https://github.com/user-attachments/assets/68fae5bc-6052-4a4a-8f25-954eb9e5cfbe" />


### 새 대화 시작 (세션 생성) 성공
<img width="1458" height="941" alt="세션생성완료함" src="https://github.com/user-attachments/assets/89e23542-05b1-4442-b4cb-5fc51f90e575" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 챗봇 세션을 생성할 수 있는 기능이 추가되었습니다.
  * 사용 가능한 챗봇 유형을 조회할 수 있는 기능이 추가되었습니다.
  * 로그인한 사용자와 비로그인 게스트 사용자 모두 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->