### PR TITLE
[FEAT] 챗봇 대화 보관함(세션 목록) + 세션 상세(메시지 목록) 조회 API 구현

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -2,6 +2,8 @@ package com.wilo.server.chatbot.controller;
 
 import com.wilo.server.chatbot.dto.ChatSessionCreateRequest;
 import com.wilo.server.chatbot.dto.ChatSessionCreateResponse;
+import com.wilo.server.chatbot.dto.ChatSessionListRequest;
+import com.wilo.server.chatbot.dto.ChatSessionListResponse;
 import com.wilo.server.chatbot.service.ChatSessionService;
 import com.wilo.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,5 +44,41 @@ public class ChatSessionController {
             @Valid @RequestBody ChatSessionCreateRequest request
     ) {
         return CommonResponse.success(chatSessionService.createSession(request, guestId));
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "대화 보관함(세션 목록) 조회",
+            description = """
+                    대화 세션 목록을 커서 기반으로 조회합니다.
+                    - 정렬: lastMessageAt DESC, id DESC
+                    - 기본 status=ACTIVE
+                    - 비로그인 사용자는 X-Guest-Id 헤더 필요
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(size 범위/잘못된 status 등)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패(로그인 API)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatSessionListResponse> getSessions(
+            @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
+
+            @Parameter(description = "기본 ACTIVE, 옵션: ACTIVE/ARCHIVED", example = "ACTIVE")
+            @RequestParam(required = false) String status,
+
+            @Parameter(description = "커서(이전 페이지의 nextCursor)", example = "200")
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(description = "페이지 크기(기본 20, 최대 50)", example = "20")
+            @RequestParam(required = false) Integer size
+    ) {
+        ChatSessionListRequest request = new ChatSessionListRequest(status, cursor, size);
+        return CommonResponse.success(chatSessionService.getSessions(guestId, request));
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -13,8 +13,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 
 @RestController
@@ -51,34 +56,78 @@ public class ChatSessionController {
             summary = "대화 보관함(세션 목록) 조회",
             description = """
                     대화 세션 목록을 커서 기반으로 조회합니다.
-                    - 정렬: lastMessageAt DESC, id DESC
-                    - 기본 status=ACTIVE
-                    - 비로그인 사용자는 X-Guest-Id 헤더 필요
+                    
+                    정렬 기준:
+                    - lastMessageAt DESC
+                    - id DESC
+                    
+                    페이징 방식:
+                    - 복합 커서(lastMessageAt + id) 기반 Keyset Pagination
+                    
+                    기본값:
+                    - status = ACTIVE
+                    - size = 20
+                    
+                    제한:
+                    - size 최대 50
+                    
+                    인증 정책:
+                    - 로그인 사용자 → userId 기반 조회
+                    - 비로그인 사용자 → X-Guest-Id 헤더 필요
                     """
     )
     @ApiResponses(value = {
+
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(size 범위/잘못된 status 등)",
+
+            @ApiResponse(responseCode = "400", description = "요청 파라미터 오류(size 범위/status 오류 등)",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패(로그인 API)",
+
+            @ApiResponse(responseCode = "400", description = "비로그인 사용자의 X-Guest-Id 헤더 누락",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+
             @ApiResponse(responseCode = "500", description = "서버 오류",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<ChatSessionListResponse> getSessions(
+
             @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
-            @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
+            @RequestHeader(value = "X-Guest-Id", required = false)
+            String guestId,
 
-            @Parameter(description = "기본 ACTIVE, 옵션: ACTIVE/ARCHIVED", example = "ACTIVE")
-            @RequestParam(required = false) String status,
 
-            @Parameter(description = "커서(이전 페이지의 nextCursor)", example = "200")
-            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "기본 ACTIVE, 옵션: ACTIVE 또는 ARCHIVED", example = "ACTIVE")
+            @RequestParam(required = false)
+            @Pattern(regexp = "ACTIVE|ARCHIVED", message = "유효하지 않은 상태값입니다.")
+            String status,
 
-            @Parameter(description = "페이지 크기(기본 20, 최대 50)", example = "20")
-            @RequestParam(required = false) Integer size
+
+            @Parameter(description = "이전 페이지 마지막 세션의 lastMessageAt 값", example = "2026-02-19T10:40:00")
+            @RequestParam(required = false)
+            LocalDateTime cursorLastMessageAt,
+
+
+            @Parameter(description = "이전 페이지 마지막 세션의 sessionId 값", example = "101")
+            @RequestParam(required = false)
+            Long cursorId,
+
+
+            @Parameter(description = "페이지 크기 (기본 20, 최대 50)", example = "20")
+            @RequestParam(required = false)
+            @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+            @Max(value = 50, message = "size는 50 이하여야 합니다.")
+            Integer size
+
     ) {
-        ChatSessionListRequest request = new ChatSessionListRequest(status, cursor, size);
+
+        ChatSessionListRequest request =
+                new ChatSessionListRequest(
+                        status,
+                        cursorLastMessageAt,
+                        cursorId,
+                        size
+                );
+
         return CommonResponse.success(chatSessionService.getSessions(guestId, request));
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionDetailController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionDetailController.java
@@ -1,0 +1,60 @@
+package com.wilo.server.chatbot.controller;
+
+import com.wilo.server.chatbot.dto.ChatSessionDetailResponse;
+import com.wilo.server.chatbot.service.ChatSessionQueryService;
+import com.wilo.server.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat/sessions")
+public class ChatSessionDetailController {
+
+    private final ChatSessionQueryService chatSessionQueryService;
+
+    @GetMapping("/{sessionId}")
+    @Operation(
+            summary = "세션 상세 조회(메시지 목록)",
+            description = """
+                    대화 세션 메타 정보 + 메시지 목록을 조회합니다.
+                    - 메시지 페이징: messageId DESC 커서 기반
+                    - 비로그인 사용자는 X-Guest-Id 헤더 필수
+                    - 세션 소유자만 접근 가능
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "파라미터 오류(size/cursor)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 없음(남의 세션 접근)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "세션 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatSessionDetailResponse> getSessionDetail(
+            @Parameter(description = "세션 ID", example = "101")
+            @PathVariable Long sessionId,
+
+            @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
+
+            @Parameter(description = "메시지 커서(기준: messageId DESC)", example = "9000")
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(description = "기본 30, 최대 100", example = "30")
+            @RequestParam(required = false) Integer size
+    ) {
+        return CommonResponse.success(
+                chatSessionQueryService.getSessionDetail(sessionId, guestId, cursor, size)
+        );
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageAttachmentDto.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageAttachmentDto.java
@@ -1,0 +1,12 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageAttachmentDto {
+    private Long mediaId;
+    private String url;
+    private String mediaType;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageDto.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageDto.java
@@ -1,0 +1,23 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatMessageDto {
+    private Long messageId;
+    private String senderType;
+    private String messageType;
+    private String content;
+    private LocalDateTime createdAt;
+
+    // 봇 전용(없으면 null)
+    private String safetyStatus;
+    private List<String> choices;
+
+    private List<ChatMessageAttachmentDto> attachments;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageDto.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageDto.java
@@ -1,5 +1,8 @@
 package com.wilo.server.chatbot.dto;
 
+import com.wilo.server.chatbot.entity.MessageType;
+import com.wilo.server.chatbot.entity.SafetyStatus;
+import com.wilo.server.chatbot.entity.SenderType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,13 +13,13 @@ import java.util.List;
 @Builder
 public class ChatMessageDto {
     private Long messageId;
-    private String senderType;
-    private String messageType;
+    private SenderType senderType;
+    private MessageType messageType;
     private String content;
     private LocalDateTime createdAt;
 
     // 봇 전용(없으면 null)
-    private String safetyStatus;
+    private SafetyStatus safetyStatus;
     private List<String> choices;
 
     private List<ChatMessageAttachmentDto> attachments;

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionDetailResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionDetailResponse.java
@@ -1,0 +1,18 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatSessionDetailResponse {
+
+    private ChatSessionSummaryDto session;
+    private List<ChatMessageDto> messages;
+    private ChatSessionMemorySummaryDto summary;
+
+    private Long nextCursor;
+    private boolean hasNext;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListItem.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListItem.java
@@ -1,0 +1,16 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatSessionListItem {
+    private Long sessionId;
+    private String title;
+    private ChatbotTypeDto chatbotType;
+    private String status;
+    private LocalDateTime lastMessageAt;
+    private String preview;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListRequest.java
@@ -1,10 +1,7 @@
 package com.wilo.server.chatbot.dto;
 
-import lombok.Getter;
-
-@Getter
-public class ChatSessionListRequest {
-    private String status;
-    private Long cursor;
-    private Integer size;
-}
+public record ChatSessionListRequest(
+        String status,
+        Long cursor,
+        Integer size
+) { }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListRequest.java
@@ -1,0 +1,10 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChatSessionListRequest {
+    private String status;
+    private Long cursor;
+    private Integer size;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListRequest.java
@@ -1,7 +1,10 @@
 package com.wilo.server.chatbot.dto;
 
+import java.time.LocalDateTime;
+
 public record ChatSessionListRequest(
         String status,
-        Long cursor,
+        LocalDateTime cursorLastMessageAt,
+        Long cursorId,
         Integer size
-) { }
+) {}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListResponse.java
@@ -1,0 +1,14 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatSessionListResponse {
+    private List<ChatSessionListItem> sessions;
+    private Long nextCursor;
+    private boolean hasNext;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListResponse.java
@@ -3,12 +3,14 @@ package com.wilo.server.chatbot.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Builder
 public class ChatSessionListResponse {
     private List<ChatSessionListItem> sessions;
-    private Long nextCursor;
+    private LocalDateTime nextCursorLastMessageAt;
+    private Long nextCursorId;
     private boolean hasNext;
 }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionMemorySummaryDto.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionMemorySummaryDto.java
@@ -1,0 +1,13 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatSessionMemorySummaryDto {
+    private boolean exists;
+    private String text;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionSummaryDto.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionSummaryDto.java
@@ -1,0 +1,13 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatSessionSummaryDto {
+    private Long sessionId;
+    private String title;
+    private String status;
+    private ChatbotTypeDto chatbotType;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeDto.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeDto.java
@@ -1,0 +1,11 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatbotTypeDto {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
@@ -1,0 +1,40 @@
+package com.wilo.server.chatbot.entity;
+
+import com.wilo.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chat_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "session_id", nullable = false)
+    private Long sessionId;
+
+    @Column(name = "sender_type", nullable = false, length = 20)
+    private String senderType; // USER, BOT
+
+    @Column(name = "message_type", nullable = false, length = 20)
+    private String messageType; // TEXT, IMAGE, VOICE
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    // 봇 메시지에만 적용 (SAFE/WARNING/CRITICAL)
+    @Column(name = "safety_status", length = 20)
+    private String safetyStatus;
+
+    // 봇 메시지 choices 3개를 JSON 문자열로 저장
+    @Lob
+    @Column(name = "choices_json")
+    private String choicesJson;
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
@@ -19,19 +19,22 @@ public class ChatMessage extends BaseEntity {
     @Column(name = "session_id", nullable = false)
     private Long sessionId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "sender_type", nullable = false, length = 20)
-    private String senderType; // USER, BOT
+    private SenderType senderType;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "message_type", nullable = false, length = 20)
-    private String messageType; // TEXT, IMAGE, VOICE
+    private MessageType messageType;
 
     @Lob
     @Column(nullable = false)
     private String content;
 
     // 봇 메시지에만 적용 (SAFE/WARNING/CRITICAL)
+    @Enumerated(EnumType.STRING)
     @Column(name = "safety_status", length = 20)
-    private String safetyStatus;
+    private SafetyStatus safetyStatus;
 
     // 봇 메시지 choices 3개를 JSON 문자열로 저장
     @Lob

--- a/src/main/java/com/wilo/server/chatbot/entity/MessageType.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/MessageType.java
@@ -1,0 +1,3 @@
+package com.wilo.server.chatbot.entity;
+
+public enum MessageType { TEXT, IMAGE, VOICE }

--- a/src/main/java/com/wilo/server/chatbot/entity/SafetyStatus.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/SafetyStatus.java
@@ -1,0 +1,3 @@
+package com.wilo.server.chatbot.entity;
+
+public enum SafetyStatus { SAFE, WARNING, CRITICAL }

--- a/src/main/java/com/wilo/server/chatbot/entity/SenderType.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/SenderType.java
@@ -1,0 +1,3 @@
+package com.wilo.server.chatbot.entity;
+
+public enum SenderType { USER, BOT }

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -11,7 +11,10 @@ public enum ChatbotErrorCase implements ErrorCase {
     CHATBOT_INTERNAL_SERVER_ERROR(500, 3001, "서버 오류가 발생했습니다."),
     CHATBOT_TYPE_NOT_FOUND(404, 3002, "존재하지 않는 챗봇 유형입니다."),
     INVALID_PARAMETER(400, 3003, "요청 파라미터가 올바르지 않습니다."),
-    GUEST_ID_REQUIRED(400, 3004, "비로그인 사용자는 X-Guest-Id 헤더가 필요합니다.");
+    GUEST_ID_REQUIRED(400, 3004, "비로그인 사용자는 X-Guest-Id 헤더가 필요합니다."),
+    SESSION_FORBIDDEN(403, 3005, "접근 권한이 없습니다."),
+    SESSION_NOT_FOUND(404, 3006, "대화 세션을 찾을 수 없습니다.");
+
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -10,7 +10,8 @@ public enum ChatbotErrorCase implements ErrorCase {
 
     CHATBOT_INTERNAL_SERVER_ERROR(500, 3001, "서버 오류가 발생했습니다."),
     CHATBOT_TYPE_NOT_FOUND(404, 3002, "존재하지 않는 챗봇 유형입니다."),
-    GUEST_ID_REQUIRED(400, 3003, "비로그인 사용자는 X-Guest-Id 헤더가 필요합니다.");
+    INVALID_PARAMETER(400, 3003, "요청 파라미터가 올바르지 않습니다."),
+    GUEST_ID_REQUIRED(400, 3004, "비로그인 사용자는 X-Guest-Id 헤더가 필요합니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -1,0 +1,25 @@
+package com.wilo.server.chatbot.repository;
+
+import com.wilo.server.chatbot.entity.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    @Query("""
+        select m
+        from ChatMessage m
+        where m.sessionId = :sessionId
+          and (:cursor is null or m.id < :cursor)
+        order by m.id desc
+    """)
+    List<ChatMessage> findBySessionIdCursorDesc(
+            @Param("sessionId") Long sessionId,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
@@ -2,6 +2,7 @@ package com.wilo.server.chatbot.repository;
 
 import com.wilo.server.chatbot.entity.ChatSession;
 import com.wilo.server.chatbot.entity.ChatSessionStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,11 +19,8 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
                 or
                 (:guestId is not null and cs.guestId = :guestId)
             )
-        and cs.status = :status
-        and (
-            :cursor is null
-            or cs.id < :cursor
-        )
+          and cs.status = :status
+          and (:cursor is null or cs.id < :cursor)
         order by cs.lastMessageAt desc nulls last, cs.id desc
     """)
     List<ChatSession> findSessions(
@@ -30,6 +28,6 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
             @Param("guestId") String guestId,
             @Param("status") ChatSessionStatus status,
             @Param("cursor") Long cursor,
-            org.springframework.data.domain.Pageable pageable
+            Pageable pageable
     );
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
@@ -1,7 +1,35 @@
 package com.wilo.server.chatbot.repository;
 
 import com.wilo.server.chatbot.entity.ChatSession;
+import com.wilo.server.chatbot.entity.ChatSessionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+    @Query("""
+        select cs
+        from ChatSession cs
+        where
+            (
+                (:userId is not null and cs.userId = :userId)
+                or
+                (:guestId is not null and cs.guestId = :guestId)
+            )
+        and cs.status = :status
+        and (
+            :cursor is null
+            or cs.id < :cursor
+        )
+        order by cs.lastMessageAt desc nulls last, cs.id desc
+    """)
+    List<ChatSession> findSessions(
+            @Param("userId") Long userId,
+            @Param("guestId") String guestId,
+            @Param("status") ChatSessionStatus status,
+            @Param("cursor") Long cursor,
+            org.springframework.data.domain.Pageable pageable
+    );
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
@@ -7,12 +7,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
     @Query("""
         select cs
         from ChatSession cs
+            left join fetch cs.chatbotType
         where
             (
                 (:userId is not null and cs.userId = :userId)
@@ -20,14 +22,20 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
                 (:guestId is not null and cs.guestId = :guestId)
             )
           and cs.status = :status
-          and (:cursor is null or cs.id < :cursor)
+          and (
+                :cursorLastMessageAt is null
+                or cs.lastMessageAt < :cursorLastMessageAt
+                or (cs.lastMessageAt = :cursorLastMessageAt and cs.id < :cursorId)
+                or (cs.lastMessageAt is null and :cursorLastMessageAt is null and cs.id < :cursorId)
+          )
         order by cs.lastMessageAt desc nulls last, cs.id desc
     """)
     List<ChatSession> findSessions(
             @Param("userId") Long userId,
             @Param("guestId") String guestId,
             @Param("status") ChatSessionStatus status,
-            @Param("cursor") Long cursor,
+            @Param("cursorLastMessageAt") LocalDateTime cursorLastMessageAt,
+            @Param("cursorId") Long cursorId,
             Pageable pageable
     );
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionQueryService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionQueryService.java
@@ -1,0 +1,155 @@
+package com.wilo.server.chatbot.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wilo.server.chatbot.dto.*;
+import com.wilo.server.chatbot.entity.ChatMessage;
+import com.wilo.server.chatbot.entity.ChatSession;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatMessageRepository;
+import com.wilo.server.chatbot.repository.ChatSessionRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatSessionQueryService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional(readOnly = true)
+    public ChatSessionDetailResponse getSessionDetail(
+            Long sessionId,
+            String guestIdHeader,
+            Long cursor,
+            Integer size
+    ) {
+        Long userId = extractUserIdIfAuthenticated();
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (userId == null && guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        // 파라미터 검증
+        int pageSize = (size == null) ? 30 : size;
+        if (pageSize < 1 || pageSize > 100) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+
+        if (cursor != null && cursor <= 0) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+
+        // 세션 조회
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        // userId 또는 guestId 소유자만
+        boolean isOwner =
+                (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+
+        if (!isOwner) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        }
+
+        // 메시지 조회 => id DESC 커서 페이징
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
+
+        List<ChatMessage> messagesDesc = chatMessageRepository.findBySessionIdCursorDesc(
+                sessionId,
+                cursor,
+                pageable
+        );
+
+        boolean hasNext = messagesDesc.size() > pageSize;
+        if (hasNext) {
+            messagesDesc = messagesDesc.subList(0, pageSize);
+        }
+
+        // 응답은 오래된 → 최신
+        Collections.reverse(messagesDesc);
+
+        List<ChatMessageDto> messageDtos = messagesDesc.stream()
+                .map(this::toMessageDto)
+                .toList();
+
+        Long nextCursor = hasNext ? messagesDesc.get(0).getId() : null;
+
+        Long safeNextCursor = hasNext
+                ? messagesDesc.stream().map(ChatMessage::getId).min(Long::compareTo).orElse(null)
+                : null;
+
+        return ChatSessionDetailResponse.builder()
+                .session(toSessionSummary(session))
+                .messages(messageDtos)
+                .summary(ChatSessionMemorySummaryDto.builder()
+                        .exists(false)
+                        .text(null)
+                        .updatedAt(null)
+                        .build())
+                .nextCursor(safeNextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    private ChatSessionSummaryDto toSessionSummary(ChatSession session) {
+        return ChatSessionSummaryDto.builder()
+                .sessionId(session.getId())
+                .title(session.getTitle())
+                .status(session.getStatus().name())
+                .chatbotType(ChatbotTypeDto.builder()
+                        .id(session.getChatbotType().getId())
+                        .name(session.getChatbotType().getName())
+                        .build())
+                .build();
+    }
+
+    private ChatMessageDto toMessageDto(ChatMessage m) {
+        List<String> choices = null;
+
+        if (m.getChoicesJson() != null && !m.getChoicesJson().isBlank()) {
+            try {
+                choices = objectMapper.readValue(m.getChoicesJson(), new TypeReference<List<String>>() {});
+            } catch (Exception e) {
+                choices = null;
+            }
+        }
+
+        return ChatMessageDto.builder()
+                .messageId(m.getId())
+                .senderType(m.getSenderType())
+                .messageType(m.getMessageType())
+                .content(m.getContent())
+                .createdAt(m.getCreatedAt())
+                .safetyStatus(m.getSafetyStatus())
+                .choices(choices)
+                .attachments(List.of()) // attachment 테이블 붙이면 조회해서 채우기
+                .build();
+    }
+
+    private String normalizeGuestId(String guestIdHeader) {
+        if (guestIdHeader == null) return null;
+        String trimmed = guestIdHeader.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private Long extractUserIdIfAuthenticated() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) return null;
+        if (auth.getPrincipal() instanceof Long userId) return userId;
+        return null;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionQueryService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionQueryService.java
@@ -26,7 +26,7 @@ public class ChatSessionQueryService {
     private final ChatSessionRepository chatSessionRepository;
     private final ChatMessageRepository chatMessageRepository;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Transactional(readOnly = true)
     public ChatSessionDetailResponse getSessionDetail(

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -75,7 +75,7 @@ public class ChatSessionService {
         if (status == ChatSessionStatus.DELETED) {
             throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
         }
-        
+
         // size default=20, max=50
         int size = (request.size() == null) ? 20 : request.size();
         if (size < 1 || size > 50) {

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -72,6 +72,10 @@ public class ChatSessionService {
             }
         }
 
+        if (status == ChatSessionStatus.DELETED) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+        
         // size default=20, max=50
         int size = (request.size() == null) ? 20 : request.size();
         if (size < 1 || size > 50) {
@@ -79,6 +83,10 @@ public class ChatSessionService {
         }
 
         Long cursor = request.cursor();
+
+        if (cursor != null && cursor <= 0) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
 
         Pageable pageable = PageRequest.of(0, size + 1);
 
@@ -109,7 +117,7 @@ public class ChatSessionService {
     }
 
     private ChatSessionListItem toItem(ChatSession session) {
-        String preview = null;
+        String preview = session.getTitle();
 
         return ChatSessionListItem.builder()
                 .sessionId(session.getId())

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -1,16 +1,20 @@
 package com.wilo.server.chatbot.service;
 
-import com.wilo.server.chatbot.dto.ChatSessionCreateRequest;
-import com.wilo.server.chatbot.dto.ChatSessionCreateResponse;
+import com.wilo.server.chatbot.dto.*;
 import com.wilo.server.chatbot.entity.ChatSession;
+import com.wilo.server.chatbot.entity.ChatSessionStatus;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
 import com.wilo.server.chatbot.repository.ChatSessionRepository;
 import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
 import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -43,6 +47,81 @@ public class ChatSessionService {
 
         ChatSession saved = chatSessionRepository.save(session);
         return ChatSessionCreateResponse.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatSessionListResponse getSessions(
+            String guestIdHeader,
+            ChatSessionListRequest request
+    ) {
+        Long userId = extractUserIdIfAuthenticated();
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        // 비로그인인데 guestId 없으면 불가
+        if (userId == null && guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        // status default = ACTIVE
+        ChatSessionStatus status = ChatSessionStatus.ACTIVE;
+        if (request.status() != null && !request.status().isBlank()) {
+            try {
+                status = ChatSessionStatus.valueOf(request.status());
+            } catch (IllegalArgumentException e) {
+                throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+            }
+        }
+
+        // size default=20, max=50
+        int size = (request.size() == null) ? 20 : request.size();
+        if (size < 1 || size > 50) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+
+        Long cursor = request.cursor();
+
+        Pageable pageable = PageRequest.of(0, size + 1);
+
+        List<ChatSession> sessions = chatSessionRepository.findSessions(
+                userId,
+                guestId,
+                status,
+                cursor,
+                pageable
+        );
+
+        boolean hasNext = sessions.size() > size;
+        if (hasNext) {
+            sessions = sessions.subList(0, size);
+        }
+
+        List<ChatSessionListItem> items = sessions.stream()
+                .map(this::toItem)
+                .toList();
+
+        Long nextCursor = hasNext ? sessions.get(sessions.size() - 1).getId() : null;
+
+        return ChatSessionListResponse.builder()
+                .sessions(items)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    private ChatSessionListItem toItem(ChatSession session) {
+        String preview = null;
+
+        return ChatSessionListItem.builder()
+                .sessionId(session.getId())
+                .title(session.getTitle())
+                .chatbotType(ChatbotTypeDto.builder()
+                        .id(session.getChatbotType().getId())
+                        .name(session.getChatbotType().getName())
+                        .build())
+                .status(session.getStatus().name())
+                .lastMessageAt(session.getLastMessageAt())
+                .preview(preview)
+                .build();
     }
 
     private String normalizeGuestId(String guestIdHeader) {

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -55,9 +56,8 @@ public class ChatSessionService {
             ChatSessionListRequest request
     ) {
         Long userId = extractUserIdIfAuthenticated();
-        String guestId = normalizeGuestId(guestIdHeader);
+        String guestId = (userId != null) ? null : normalizeGuestId(guestIdHeader);
 
-        // 비로그인인데 guestId 없으면 불가
         if (userId == null && guestId == null) {
             throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
         }
@@ -82,9 +82,14 @@ public class ChatSessionService {
             throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
         }
 
-        Long cursor = request.cursor();
+        LocalDateTime cursorLastMessageAt = request.cursorLastMessageAt();
+        Long cursorId = request.cursorId();
 
-        if (cursor != null && cursor <= 0) {
+        if (cursorId != null && cursorId <= 0) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+
+        if ((cursorLastMessageAt == null) != (cursorId == null)) {
             throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
         }
 
@@ -94,7 +99,8 @@ public class ChatSessionService {
                 userId,
                 guestId,
                 status,
-                cursor,
+                cursorLastMessageAt,
+                cursorId,
                 pageable
         );
 
@@ -107,11 +113,19 @@ public class ChatSessionService {
                 .map(this::toItem)
                 .toList();
 
-        Long nextCursor = hasNext ? sessions.get(sessions.size() - 1).getId() : null;
+        LocalDateTime nextCursorLastMessageAt = null;
+        Long nextCursorId = null;
+
+        if (hasNext && !sessions.isEmpty()) {
+            ChatSession last = sessions.get(sessions.size() - 1);
+            nextCursorLastMessageAt = last.getLastMessageAt();
+            nextCursorId = last.getId();
+        }
 
         return ChatSessionListResponse.builder()
                 .sessions(items)
-                .nextCursor(nextCursor)
+                .nextCursorLastMessageAt(nextCursorLastMessageAt)
+                .nextCursorId(nextCursorId)
                 .hasNext(hasNext)
                 .build();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #16 

## 📝 작업 내용

### 1) 대화 보관함(세션 목록) 조회 API 구현
- `GET /api/v1/chat/sessions`
- 로그인 사용자: JWT 기반 userId로 세션 조회
- 비로그인 사용자: `X-Guest-Id` 헤더 기반 guestId로 세션 조회
- Query 지원
- Cursor 기반 페이징 적용

### 2) 세션 상세(메시지 목록) 조회 API 구현
- `GET /api/v1/chat/sessions/{sessionId}`
- 세션 메타 + 메시지 목록을 함께 반환
- Query 지원
- Cursor 기반 페이징 적용


## 🖼️ 스크린샷 (선택)
### 세션 목록 조회 성공
<img width="1473" height="943" alt="세션목록조회성공" src="https://github.com/user-attachments/assets/bc299007-0caa-433a-8603-7388b8f40169" />

### 세션 상세 조회 성공
<img width="1467" height="940" alt="세션상세조회성공" src="https://github.com/user-attachments/assets/da41366a-f3ec-4c0a-b7c8-05e334aab3c6" />

### 세션 조회 실패 (X-Guest-Id 다름)
<img width="1473" height="945" alt="게스트ID권한실패" src="https://github.com/user-attachments/assets/8a767392-38e5-4d5a-9ae9-1bf9e102e694" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 채팅 세션 목록 조회 API - 페이지네이션 지원으로 세션 목록을 효율적으로 조회 가능
* 채팅 세션 상세 정보 조회 API - 메시지, 세션 요약, 메모리 데이터를 포함한 상세 정보 제공

## 버그 수정
* 세션 접근 권한 검증 및 요청 매개변수 검증 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->