### PR TITLE
[FEAT] 메시지 전송, 세션 (제목 수정, 보관, 복구) API 구현  

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 sentry {

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// WebClient
-	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 

--- a/src/main/java/com/wilo/server/chatbot/client/AiChatClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiChatClient.java
@@ -1,0 +1,5 @@
+package com.wilo.server.chatbot.client;
+
+public interface AiChatClient {
+    AiChatResult chat(AiChatCommand command);
+}

--- a/src/main/java/com/wilo/server/chatbot/client/AiChatCommand.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiChatCommand.java
@@ -1,0 +1,13 @@
+package com.wilo.server.chatbot.client;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiChatCommand {
+    private String userId;      // userId or guestId 문자열
+    private Long sessionId;
+    private Long personaId;     // chatbotTypeId
+    private String message;
+}

--- a/src/main/java/com/wilo/server/chatbot/client/AiChatResult.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiChatResult.java
@@ -1,0 +1,16 @@
+package com.wilo.server.chatbot.client;
+
+import com.wilo.server.chatbot.entity.SafetyStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AiChatResult {
+    private Long sessionId;
+    private String answer;
+    private List<String> choices;
+    private SafetyStatus safetyStatus;
+}

--- a/src/main/java/com/wilo/server/chatbot/client/AiClientConfig.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiClientConfig.java
@@ -1,0 +1,8 @@
+package com.wilo.server.chatbot.client;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiClientConfig {
+}

--- a/src/main/java/com/wilo/server/chatbot/client/AiClientConfig.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiClientConfig.java
@@ -2,7 +2,16 @@ package com.wilo.server.chatbot.client;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.beans.factory.annotation.Value;
+
 
 @Configuration
 public class AiClientConfig {
+    @Bean
+    public WebClient aiWebClient(@Value("${ai.base-url}") String baseUrl) {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/client/AiClientConfig.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiClientConfig.java
@@ -1,17 +1,29 @@
 package com.wilo.server.chatbot.client;
 
+import io.netty.channel.ChannelOption;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.beans.factory.annotation.Value;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
 
 
 @Configuration
 public class AiClientConfig {
     @Bean
     public WebClient aiWebClient(@Value("${ai.base-url}") String baseUrl) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
+                .responseTimeout(Duration.ofSeconds(30));
         return WebClient.builder()
                 .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create().responseTimeout(Duration.ofSeconds(5))))
+                .codecs(configurer -> configurer
+                        .defaultCodecs()
+                        .maxInMemorySize(1024 * 1024))
                 .build();
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/client/AiResponseMapper.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiResponseMapper.java
@@ -1,0 +1,63 @@
+package com.wilo.server.chatbot.client;
+
+import com.wilo.server.chatbot.entity.SafetyStatus;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.global.exception.ApplicationException;
+
+import java.util.List;
+import java.util.Map;
+
+public class AiResponseMapper {
+
+    private AiResponseMapper() {}
+
+    public static AiChatResult toResult(Map<String, Object> res) {
+
+        Object answerObj = res.get("answer");
+        Object safetyObj = res.get("safety_status");
+        Object choicesObj = res.get("choices");
+        Object sessionIdObj = res.get("session_id");
+
+        if (!(answerObj instanceof String answer) || answer.isBlank()) {
+            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+        }
+
+        SafetyStatus safetyStatus = null;
+        if (safetyObj != null) {
+            if (!(safetyObj instanceof String s)) {
+                throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+            }
+            try {
+                safetyStatus = SafetyStatus.valueOf(s);
+            } catch (IllegalArgumentException e) {
+                throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+            }
+        }
+
+        List<String> choices = null;
+        if (choicesObj != null) {
+            if (!(choicesObj instanceof List<?> rawList)) {
+                throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+            }
+            choices = rawList.stream()
+                    .map(v -> (v instanceof String str) ? str : null)
+                    .toList();
+
+            if (choices.stream().anyMatch(v -> v == null)) {
+                throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+            }
+        }
+
+        Long sessionId = null;
+        if (sessionIdObj instanceof Number n) {
+            sessionId = n.longValue();
+        }
+
+        return AiChatResult.builder()
+                .sessionId(sessionId)
+                .answer(answer)
+                .choices(choices)
+                .safetyStatus(safetyStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
@@ -1,9 +1,49 @@
 package com.wilo.server.chatbot.client;
 
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-public class RealAiChatClient {
+public class RealAiChatClient implements AiChatClient {
+
+    private final WebClient aiWebClient;
+
+    @Override
+    public AiChatResult chat(AiChatCommand command) {
+        try {
+            Map<String, Object> body = Map.of(
+                    "user_id", command.getUserId(),
+                    "session_id", command.getSessionId(),
+                    "persona_id", command.getPersonaId(),
+                    "message", command.getMessage()
+            );
+
+            // AI 서버 응답도 Map으로 먼저 받고, 백엔드에서 파싱
+            Map<String, Object> res = aiWebClient.post()
+                    .uri("/chat")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(Map.class)
+                    .block();
+
+            if (res == null) {
+                throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
+            }
+
+            return AiResponseMapper.toResult(res);
+
+        } catch (ApplicationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED, e);
+        }
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
@@ -1,0 +1,4 @@
+package com.wilo.server.chatbot.client;
+
+public class RealAiChatClient {
+}

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
@@ -1,4 +1,9 @@
 package com.wilo.server.chatbot.client;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class RealAiChatClient {
 }

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatMessageController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatMessageController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -47,6 +48,7 @@ public class ChatMessageController {
     })
     public CommonResponse<ChatMessageSendResponse> sendMessage(
             @Parameter(description = "대화 세션 ID", example = "101")
+            @Min(value = 1, message = "sessionId는 1 이상이어야 합니다.")
             @PathVariable Long sessionId,
             @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
             @RequestHeader(value = "X-Guest-Id", required = false)

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatMessageController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatMessageController.java
@@ -1,0 +1,60 @@
+package com.wilo.server.chatbot.controller;
+
+import com.wilo.server.chatbot.dto.ChatMessageSendRequest;
+import com.wilo.server.chatbot.dto.ChatMessageSendResponse;
+import com.wilo.server.chatbot.service.ChatMessageService;
+import com.wilo.server.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat/sessions")
+public class ChatMessageController {
+
+    private final ChatMessageService chatMessageService;
+
+    @PostMapping("/{sessionId}/messages")
+    @Operation(
+            summary = "메시지 전송(사용자 → AI → 응답 저장 후 반환)",
+            description = """
+                    사용자가 입력한 메시지를 저장하고, 백엔드가 AI 서버 /chat을 호출하여
+                    봇 답변을 생성/저장한 뒤 USER/BOT 메시지를 함께 반환합니다. 
+                    
+                    - 로그인 사용자: JWT userId 기반
+                    - 비로그인 사용자: X-Guest-Id 헤더 기반
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전송 성공"),
+            @ApiResponse(responseCode = "400", description = "게스트 헤더 누락/요청값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "세션 접근 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "세션 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "502", description = "AI 서버 오류/응답 형식 불일치",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatMessageSendResponse> sendMessage(
+            @Parameter(description = "대화 세션 ID", example = "101")
+            @PathVariable Long sessionId,
+            @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false)
+            String guestId,
+            @Valid @RequestBody ChatMessageSendRequest request
+    ) {
+        return CommonResponse.success(
+                chatMessageService.sendMessage(sessionId, guestId, request)
+        );
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -150,4 +150,31 @@ public class ChatSessionController {
     ) {
         return CommonResponse.success(chatSessionService.updateSessionTitle(sessionId, guestId, request));
     }
+
+    @PatchMapping("/{sessionId}/archive")
+    @Operation(
+            summary = "세션 보관",
+            description = """
+                대화 세션을 ARCHIVED 상태로 변경합니다.
+                - 로그인 사용자는 user_id 기준
+                - 비로그인 사용자는 X-Guest-Id 기준
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "보관 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "세션 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatSessionArchiveResponse> archiveSession(
+            @Parameter(description = "세션 ID", example = "101")
+            @PathVariable Long sessionId,
+            @Parameter(description = "비로그인 사용자 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId
+    ) {
+        return CommonResponse.success(chatSessionService.archiveSession(sessionId, guestId));
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -177,4 +177,33 @@ public class ChatSessionController {
     ) {
         return CommonResponse.success(chatSessionService.archiveSession(sessionId, guestId));
     }
+
+    @PatchMapping("/{sessionId}/restore")
+    @Operation(
+            summary = "세션 복원",
+            description = """
+                ARCHIVED 상태의 대화 세션을 ACTIVE로 복원합니다.
+                - 로그인 사용자는 user_id 기준
+                - 비로그인 사용자는 X-Guest-Id 기준
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "복원 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 상태(ARCHIVED가 아님) 또는 요청값 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "세션 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatSessionRestoreResponse> restoreSession(
+            @Parameter(description = "세션 ID", example = "101")
+            @PathVariable Long sessionId,
+            @Parameter(description = "비로그인 사용자 UUID. 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId
+    ) {
+        return CommonResponse.success(chatSessionService.restoreSession(sessionId, guestId));
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -143,6 +143,7 @@ public class ChatSessionController {
     public CommonResponse<ChatSessionTitleUpdateResponse> updateSessionTitle(
 
             @Parameter(description = "세션 ID", example = "101")
+            @Min(value = 1, message = "sessionId는 1 이상이어야 합니다.")
             @PathVariable Long sessionId,
             @Parameter(description = "비로그인 사용자 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
             @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
@@ -171,6 +172,7 @@ public class ChatSessionController {
     })
     public CommonResponse<ChatSessionArchiveResponse> archiveSession(
             @Parameter(description = "세션 ID", example = "101")
+            @Min(value = 1, message = "sessionId는 1 이상이어야 합니다.")
             @PathVariable Long sessionId,
             @Parameter(description = "비로그인 사용자 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
             @RequestHeader(value = "X-Guest-Id", required = false) String guestId
@@ -200,6 +202,7 @@ public class ChatSessionController {
     })
     public CommonResponse<ChatSessionRestoreResponse> restoreSession(
             @Parameter(description = "세션 ID", example = "101")
+            @Min(value = 1, message = "sessionId는 1 이상이어야 합니다.")
             @PathVariable Long sessionId,
             @Parameter(description = "비로그인 사용자 UUID. 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
             @RequestHeader(value = "X-Guest-Id", required = false) String guestId

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -1,9 +1,6 @@
 package com.wilo.server.chatbot.controller;
 
-import com.wilo.server.chatbot.dto.ChatSessionCreateRequest;
-import com.wilo.server.chatbot.dto.ChatSessionCreateResponse;
-import com.wilo.server.chatbot.dto.ChatSessionListRequest;
-import com.wilo.server.chatbot.dto.ChatSessionListResponse;
+import com.wilo.server.chatbot.dto.*;
 import com.wilo.server.chatbot.service.ChatSessionService;
 import com.wilo.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -90,36 +87,29 @@ public class ChatSessionController {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<ChatSessionListResponse> getSessions(
-
             @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
             @RequestHeader(value = "X-Guest-Id", required = false)
             String guestId,
-
 
             @Parameter(description = "기본 ACTIVE, 옵션: ACTIVE 또는 ARCHIVED", example = "ACTIVE")
             @RequestParam(required = false)
             @Pattern(regexp = "ACTIVE|ARCHIVED", message = "유효하지 않은 상태값입니다.")
             String status,
 
-
             @Parameter(description = "이전 페이지 마지막 세션의 lastMessageAt 값", example = "2026-02-19T10:40:00")
             @RequestParam(required = false)
             LocalDateTime cursorLastMessageAt,
 
-
             @Parameter(description = "이전 페이지 마지막 세션의 sessionId 값", example = "101")
             @RequestParam(required = false)
             Long cursorId,
-
 
             @Parameter(description = "페이지 크기 (기본 20, 최대 50)", example = "20")
             @RequestParam(required = false)
             @Min(value = 1, message = "size는 1 이상이어야 합니다.")
             @Max(value = 50, message = "size는 50 이하여야 합니다.")
             Integer size
-
     ) {
-
         ChatSessionListRequest request =
                 new ChatSessionListRequest(
                         status,
@@ -127,7 +117,37 @@ public class ChatSessionController {
                         cursorId,
                         size
                 );
-
         return CommonResponse.success(chatSessionService.getSessions(guestId, request));
+    }
+
+    @PatchMapping("/{sessionId}")
+    @Operation(
+            summary = "세션 제목 수정",
+            description = """
+                대화 세션 제목을 수정합니다.
+                - 로그인 사용자는 user_id 기준
+                - 비로그인은 X-Guest-Id 기준
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "제목 정책 위반",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "세션 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatSessionTitleUpdateResponse> updateSessionTitle(
+
+            @Parameter(description = "세션 ID", example = "101")
+            @PathVariable Long sessionId,
+            @Parameter(description = "비로그인 사용자 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
+            @Valid @RequestBody ChatSessionTitleUpdateRequest request
+    ) {
+        return CommonResponse.success(chatSessionService.updateSessionTitle(sessionId, guestId, request));
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendRequest.java
@@ -1,6 +1,7 @@
 package com.wilo.server.chatbot.dto;
 
 import com.wilo.server.chatbot.entity.MessageType;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,5 +14,6 @@ public class ChatMessageSendRequest {
     private MessageType messageType;
 
     @NotBlank(message = "message는 필수입니다.")
+    @Size(max = 4000, message = "message는 4000자 이하입니다.")
     private String message;
 }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendRequest.java
@@ -1,0 +1,17 @@
+package com.wilo.server.chatbot.dto;
+
+import com.wilo.server.chatbot.entity.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageSendRequest {
+    private MessageType messageType;
+
+    @NotBlank(message = "message는 필수입니다.")
+    private String message;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendResponse.java
@@ -1,0 +1,12 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageSendResponse {
+    private Long sessionId;
+    private ChatMessageDto userMessage;
+    private ChatMessageDto botMessage;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionArchiveResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionArchiveResponse.java
@@ -1,0 +1,11 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatSessionArchiveResponse {
+    private Long sessionId;
+    private String status;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionRestoreResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionRestoreResponse.java
@@ -1,0 +1,11 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatSessionRestoreResponse {
+    private Long sessionId;
+    private String status;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionTitleUpdateRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionTitleUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.wilo.server.chatbot.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ChatSessionTitleUpdateRequest {
+    @NotBlank(message = "제목은 비어 있을 수 없습니다.")
+    @Size(max = 200, message = "제목은 200자 이하입니다.")
+    private String title;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionTitleUpdateResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionTitleUpdateResponse.java
@@ -1,0 +1,11 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatSessionTitleUpdateResponse {
+    private Long sessionId;
+    private String title;
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Getter
 @Entity
 @Table(name = "chat_messages")
@@ -40,4 +41,26 @@ public class ChatMessage extends BaseEntity {
     @Lob
     @Column(name = "choices_json")
     private String choicesJson;
+
+    public static ChatMessage createUser(Long sessionId, MessageType messageType, String content) {
+        ChatMessage m = new ChatMessage();
+        m.sessionId = sessionId;
+        m.senderType = SenderType.USER;
+        m.messageType = (messageType == null) ? MessageType.TEXT : messageType;
+        m.content = content;
+        m.safetyStatus = null;
+        m.choicesJson = null;
+        return m;
+    }
+
+    public static ChatMessage createBot(Long sessionId, String content, SafetyStatus safetyStatus, String choicesJson) {
+        ChatMessage m = new ChatMessage();
+        m.sessionId = sessionId;
+        m.senderType = SenderType.BOT;
+        m.messageType = MessageType.TEXT;
+        m.content = content;
+        m.safetyStatus = safetyStatus;
+        m.choicesJson = choicesJson;
+        return m;
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
@@ -42,12 +42,19 @@ public class ChatMessage extends BaseEntity {
     @Column(name = "choices_json")
     private String choicesJson;
 
+    private static String requireContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("content는 비어 있을 수 없습니다.");
+        }
+        return content;
+    }
+
     public static ChatMessage createUser(Long sessionId, MessageType messageType, String content) {
         ChatMessage m = new ChatMessage();
         m.sessionId = sessionId;
         m.senderType = SenderType.USER;
         m.messageType = (messageType == null) ? MessageType.TEXT : messageType;
-        m.content = content;
+        m.content = requireContent(content);
         m.safetyStatus = null;
         m.choicesJson = null;
         return m;
@@ -58,7 +65,7 @@ public class ChatMessage extends BaseEntity {
         m.sessionId = sessionId;
         m.senderType = SenderType.BOT;
         m.messageType = MessageType.TEXT;
-        m.content = content;
+        m.content = requireContent(content);
         m.safetyStatus = safetyStatus;
         m.choicesJson = choicesJson;
         return m;

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -64,4 +64,8 @@ public class ChatSession {
     public void updateLastMessageAt(LocalDateTime time) {
         this.lastMessageAt = time;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -68,4 +68,8 @@ public class ChatSession {
     public void updateTitle(String title) {
         this.title = title;
     }
+
+    public void archive() {
+        this.status = ChatSessionStatus.ARCHIVED;
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -72,4 +72,8 @@ public class ChatSession {
     public void archive() {
         this.status = ChatSessionStatus.ARCHIVED;
     }
+
+    public void restore() {
+        this.status = ChatSessionStatus.ACTIVE;
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -60,4 +60,8 @@ public class ChatSession {
         session.lastMessageAt = null;
         return session;
     }
+
+    public void updateLastMessageAt(LocalDateTime time) {
+        this.lastMessageAt = time;
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -13,7 +13,9 @@ public enum ChatbotErrorCase implements ErrorCase {
     INVALID_PARAMETER(400, 3003, "요청 파라미터가 올바르지 않습니다."),
     GUEST_ID_REQUIRED(400, 3004, "비로그인 사용자는 X-Guest-Id 헤더가 필요합니다."),
     SESSION_FORBIDDEN(403, 3005, "접근 권한이 없습니다."),
-    SESSION_NOT_FOUND(404, 3006, "대화 세션을 찾을 수 없습니다.");
+    SESSION_NOT_FOUND(404, 3006, "대화 세션을 찾을 수 없습니다."),
+    AI_SERVER_FAILED(502, 3101, "AI 서버 응답에 실패했습니다."),
+    AI_RESPONSE_INVALID(502, 3102, "AI 응답 형식이 올바르지 않습니다.");
 
 
     private final Integer httpStatusCode;

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -14,8 +14,9 @@ public enum ChatbotErrorCase implements ErrorCase {
     GUEST_ID_REQUIRED(400, 3004, "비로그인 사용자는 X-Guest-Id 헤더가 필요합니다."),
     SESSION_FORBIDDEN(403, 3005, "접근 권한이 없습니다."),
     SESSION_NOT_FOUND(404, 3006, "대화 세션을 찾을 수 없습니다."),
-    AI_SERVER_FAILED(502, 3101, "AI 서버 응답에 실패했습니다."),
-    AI_RESPONSE_INVALID(502, 3102, "AI 응답 형식이 올바르지 않습니다.");
+    TITLE_INVALID(400, 3007, "제목이 정책을 충족하지 않습니다."),
+    AI_SERVER_FAILED(502, 3008, "AI 서버 응답에 실패했습니다."),
+    AI_RESPONSE_INVALID(502, 3009, "AI 응답 형식이 올바르지 않습니다.");
 
 
     private final Integer httpStatusCode;

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
     @Query("""
@@ -37,5 +38,15 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
             @Param("cursorLastMessageAt") LocalDateTime cursorLastMessageAt,
             @Param("cursorId") Long cursorId,
             Pageable pageable
+    );
+
+    @Query("""
+        select cs
+        from ChatSession cs
+          join fetch cs.chatbotType
+        where cs.id = :sessionId
+    """)
+    Optional<ChatSession> findByIdWithChatbotType(
+            @Param("sessionId") Long sessionId
     );
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
@@ -16,12 +16,14 @@ import com.wilo.server.chatbot.repository.ChatMessageRepository;
 import com.wilo.server.chatbot.repository.ChatSessionRepository;
 import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -141,7 +143,8 @@ public class ChatMessageService {
                         m.getChoicesJson(),
                         new TypeReference<List<String>>() {}
                 );
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                log.warn("choices JSON 역직렬화 실패: messageId={}", m.getId(), e);
                 choices = null;
             }
         }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
@@ -1,43 +1,32 @@
 package com.wilo.server.chatbot.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wilo.server.chatbot.client.AiChatClient;
 import com.wilo.server.chatbot.client.AiChatCommand;
 import com.wilo.server.chatbot.client.AiChatResult;
-import com.wilo.server.chatbot.dto.ChatMessageDto;
 import com.wilo.server.chatbot.dto.ChatMessageSendRequest;
 import com.wilo.server.chatbot.dto.ChatMessageSendResponse;
 import com.wilo.server.chatbot.entity.ChatMessage;
-import com.wilo.server.chatbot.entity.ChatSession;
-import com.wilo.server.chatbot.entity.MessageType;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
-import com.wilo.server.chatbot.repository.ChatMessageRepository;
-import com.wilo.server.chatbot.repository.ChatSessionRepository;
 import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
 
-    private final ChatSessionRepository chatSessionRepository;
-    private final ChatMessageRepository chatMessageRepository;
     private final AiChatClient aiChatClient;
-    private final ObjectMapper objectMapper;
+    private final ChatMessageTxService chatMessageTxService;
 
     public ChatMessageSendResponse sendMessage(
             Long sessionId,
             String guestIdHeader,
             ChatMessageSendRequest request
     ) {
+
         Long userId = extractUserIdIfAuthenticated();
         String guestId = normalizeGuestId(guestIdHeader);
 
@@ -45,182 +34,48 @@ public class ChatMessageService {
             throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
         }
 
-        // 세션 조회
-        ChatSession session = loadSessionWithAuthCheck(sessionId, userId, guestId);
+        // 세션 권한 체크 + personaId 얻기
+        Long personaId = chatMessageTxService.getPersonaIdWithAuthCheck(sessionId, userId, guestId);
 
         // USER 메시지 저장
-        ChatMessage savedUser = saveUserMessage(sessionId, request);
+        ChatMessage savedUser = chatMessageTxService.saveUserMessage(sessionId, request);
 
-        // AI 서버 호출 (트랜잭션 X)
-        AiChatResult aiResult = callAi(session, userId, guestId, request);
+        // AI 호출
+        String requester = (userId != null) ? String.valueOf(userId) : guestId;
 
-        // BOT 메시지 저장
-        ChatMessage savedBot = saveBotMessage(session, aiResult);
+        AiChatResult aiResult = aiChatClient.chat(
+                AiChatCommand.builder()
+                        .userId(requester)
+                        .sessionId(sessionId)
+                        .personaId(personaId)
+                        .message(request.getMessage())
+                        .build()
+        );
+
+        if (aiResult == null || aiResult.getAnswer() == null) {
+            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+        }
+
+        // BOT 메시지 저장 + lastMessageAt 업데이트
+        ChatMessage savedBot = chatMessageTxService.saveBotMessageWithSessionUpdate(sessionId, aiResult);
 
         return ChatMessageSendResponse.builder()
                 .sessionId(sessionId)
-                .userMessage(toDto(savedUser))
-                .botMessage(toDto(savedBot))
+                .userMessage(chatMessageTxService.toDto(savedUser))
+                .botMessage(chatMessageTxService.toDto(savedBot))
                 .build();
     }
 
-
-    // 세션 조회 + 권한 체크
-    @Transactional(readOnly = true)
-    protected ChatSession loadSessionWithAuthCheck(
-            Long sessionId,
-            Long userId,
-            String guestId
-    ) {
-
-        ChatSession session =
-                chatSessionRepository.findById(sessionId)
-                        .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
-
-        boolean isOwner =
-                (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
-                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
-
-        if (!isOwner) {
-            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
-        }
-
-        return session;
-    }
-
-
-    // USER 메시지 저장
-    @Transactional
-    protected ChatMessage saveUserMessage(
-            Long sessionId,
-            ChatMessageSendRequest request
-    ) {
-        MessageType type =
-                request.getMessageType() == null
-                        ? MessageType.TEXT
-                        : request.getMessageType();
-
-        return chatMessageRepository.save(
-                ChatMessage.createUser(
-                        sessionId,
-                        type,
-                        request.getMessage()
-                )
-        );
-    }
-
-
-    // AI 서버 호출
-    private AiChatResult callAi(
-            ChatSession session,
-            Long userId,
-            String guestId,
-            ChatMessageSendRequest request
-    ) {
-        Long personaId = session.getChatbotType().getId();
-
-        String requester = userId != null ? String.valueOf(userId) : guestId;
-
-        AiChatResult result =
-                aiChatClient.chat(
-                        AiChatCommand.builder()
-                                .userId(requester)
-                                .sessionId(session.getId())
-                                .personaId(personaId)
-                                .message(request.getMessage())
-                                .build()
-                );
-
-        if (result == null || result.getAnswer() == null) {
-            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
-        }
-        return result;
-    }
-
-
-    // BOT 메시지 저장 + lastMessageAt 업데이트
-    @Transactional
-    protected ChatMessage saveBotMessage(
-            ChatSession session,
-            AiChatResult aiResult
-    ) {
-        String choicesJson = null;
-
-        if (aiResult.getChoices() != null) {
-            try {
-                choicesJson = objectMapper.writeValueAsString(aiResult.getChoices());
-            } catch (Exception e) {
-                throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID, e);
-            }
-        }
-
-        ChatMessage savedBot =
-                chatMessageRepository.save(
-                        ChatMessage.createBot(
-                                session.getId(),
-                                aiResult.getAnswer(),
-                                aiResult.getSafetyStatus(),
-                                choicesJson
-                        )
-                );
-
-        session.updateLastMessageAt(savedBot.getCreatedAt());
-        return savedBot;
-    }
-
-
-    // DTO 변환
-    private ChatMessageDto toDto(ChatMessage m) {
-        List<String> choices = null;
-
-        if (m.getChoicesJson() != null
-                && !m.getChoicesJson().isBlank()) {
-
-            try {
-                choices = objectMapper.readValue(m.getChoicesJson(), new TypeReference<List<String>>() {});
-            } catch (Exception e) {
-                log.warn("choices parse fail id={}", m.getId());
-            }
-        }
-
-        return ChatMessageDto.builder()
-                .messageId(m.getId())
-                .senderType(m.getSenderType())
-                .messageType(m.getMessageType())
-                .content(m.getContent())
-                .createdAt(m.getCreatedAt())
-                .safetyStatus(m.getSafetyStatus())
-                .choices(choices)
-                .attachments(List.of())
-                .build();
-    }
-
-
-    // guestId 정규화
     private String normalizeGuestId(String guestIdHeader) {
-
-        if (guestIdHeader == null) {
-            return null;
-        }
+        if (guestIdHeader == null) return null;
         String trimmed = guestIdHeader.trim();
-
         return trimmed.isEmpty() ? null : trimmed;
     }
 
-
-    // 로그인 userId 추출
     private Long extractUserIdIfAuthenticated() {
-
         var auth = SecurityContextHolder.getContext().getAuthentication();
-
-        if (auth == null || auth.getPrincipal() == null) {
-            return null;
-        }
-
-        if (auth.getPrincipal() instanceof Long userId) {
-            return userId;
-        }
-
+        if (auth == null || auth.getPrincipal() == null) return null;
+        if (auth.getPrincipal() instanceof Long userId) return userId;
         return null;
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
@@ -1,0 +1,187 @@
+package com.wilo.server.chatbot.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wilo.server.chatbot.client.AiChatClient;
+import com.wilo.server.chatbot.client.AiChatCommand;
+import com.wilo.server.chatbot.client.AiChatResult;
+import com.wilo.server.chatbot.dto.ChatMessageDto;
+import com.wilo.server.chatbot.dto.ChatMessageSendRequest;
+import com.wilo.server.chatbot.dto.ChatMessageSendResponse;
+import com.wilo.server.chatbot.entity.ChatMessage;
+import com.wilo.server.chatbot.entity.ChatSession;
+import com.wilo.server.chatbot.entity.MessageType;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatMessageRepository;
+import com.wilo.server.chatbot.repository.ChatSessionRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatMessageService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final AiChatClient aiChatClient;
+    private final ObjectMapper objectMapper;
+
+    public ChatMessageSendResponse sendMessage(
+            Long sessionId,
+            String guestIdHeader,
+            ChatMessageSendRequest request
+    ) {
+
+        Long userId = extractUserIdIfAuthenticated();
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        // 로그인도 아니고 guest도 아니면 불가
+        if (userId == null && guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        // 세션 조회
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() ->
+                        new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        // 세션 소유자 검증
+        boolean isOwner =
+                (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+
+        if (!isOwner) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        }
+
+        // USER 메시지 저장
+        MessageType type =
+                request.getMessageType() == null
+                        ? MessageType.TEXT
+                        : request.getMessageType();
+
+        ChatMessage savedUser =
+                chatMessageRepository.save(
+                        ChatMessage.createUser(
+                                sessionId,
+                                type,
+                                request.getMessage()
+                        )
+                );
+
+        // AI 서버 호출
+        Long personaId = session.getChatbotType().getId();
+
+        String requester = userId != null ? String.valueOf(userId) : guestId;
+
+        AiChatResult aiResult =
+                aiChatClient.chat(
+                        AiChatCommand.builder()
+                                .userId(requester)
+                                .sessionId(sessionId)
+                                .personaId(personaId)
+                                .message(request.getMessage())
+                                .build()
+                );
+
+
+        // AI 응답 검증
+        if (aiResult == null || aiResult.getAnswer() == null) {
+            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+        }
+
+        // choices JSON 변환
+        String choicesJson = null;
+
+        if (aiResult.getChoices() != null) {
+
+            try {
+                choicesJson = objectMapper.writeValueAsString(aiResult.getChoices());
+            } catch (Exception e) {
+
+                throw new ApplicationException(
+                        ChatbotErrorCase.AI_RESPONSE_INVALID, e);
+            }
+        }
+
+        // BOT 메시지 저장
+        ChatMessage savedBot =
+                chatMessageRepository.save(
+                        ChatMessage.createBot(
+                                sessionId,
+                                aiResult.getAnswer(),
+                                aiResult.getSafetyStatus(),
+                                choicesJson
+                        )
+                );
+
+        // lastMessageAt 업데이트
+        session.updateLastMessageAt(savedBot.getCreatedAt());
+
+        return ChatMessageSendResponse.builder()
+                .sessionId(sessionId)
+                .userMessage(toDto(savedUser))
+                .botMessage(toDto(savedBot))
+                .build();
+    }
+
+    private ChatMessageDto toDto(ChatMessage m) {
+
+        List<String> choices = null;
+
+        if (m.getChoicesJson() != null && !m.getChoicesJson().isBlank()) {
+            try {
+                choices = objectMapper.readValue(
+                        m.getChoicesJson(),
+                        new TypeReference<List<String>>() {}
+                );
+            } catch (Exception ignored) {
+                choices = null;
+            }
+        }
+
+        return ChatMessageDto.builder()
+                .messageId(m.getId())
+                .senderType(m.getSenderType())
+                .messageType(m.getMessageType())
+                .content(m.getContent())
+                .createdAt(m.getCreatedAt())
+                .safetyStatus(m.getSafetyStatus())
+                .choices(choices)
+                .attachments(List.of())
+                .build();
+    }
+
+    // guestId 정규화
+    private String normalizeGuestId(String guestIdHeader) {
+
+        if (guestIdHeader == null) {
+            return null;
+        }
+
+        String trimmed = guestIdHeader.trim();
+
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private Long extractUserIdIfAuthenticated() {
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || auth.getPrincipal() == null) {
+            return null;
+        }
+
+        if (auth.getPrincipal() instanceof Long userId) {
+            return userId;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
@@ -26,7 +26,6 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ChatMessageService {
 
     private final ChatSessionRepository chatSessionRepository;
@@ -39,92 +38,24 @@ public class ChatMessageService {
             String guestIdHeader,
             ChatMessageSendRequest request
     ) {
-
         Long userId = extractUserIdIfAuthenticated();
         String guestId = normalizeGuestId(guestIdHeader);
 
-        // 로그인도 아니고 guest도 아니면 불가
         if (userId == null && guestId == null) {
             throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
         }
 
         // 세션 조회
-        ChatSession session = chatSessionRepository.findById(sessionId)
-                .orElseThrow(() ->
-                        new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
-
-        // 세션 소유자 검증
-        boolean isOwner =
-                (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
-                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
-
-        if (!isOwner) {
-            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
-        }
+        ChatSession session = loadSessionWithAuthCheck(sessionId, userId, guestId);
 
         // USER 메시지 저장
-        MessageType type =
-                request.getMessageType() == null
-                        ? MessageType.TEXT
-                        : request.getMessageType();
+        ChatMessage savedUser = saveUserMessage(sessionId, request);
 
-        ChatMessage savedUser =
-                chatMessageRepository.save(
-                        ChatMessage.createUser(
-                                sessionId,
-                                type,
-                                request.getMessage()
-                        )
-                );
-
-        // AI 서버 호출
-        Long personaId = session.getChatbotType().getId();
-
-        String requester = userId != null ? String.valueOf(userId) : guestId;
-
-        AiChatResult aiResult =
-                aiChatClient.chat(
-                        AiChatCommand.builder()
-                                .userId(requester)
-                                .sessionId(sessionId)
-                                .personaId(personaId)
-                                .message(request.getMessage())
-                                .build()
-                );
-
-
-        // AI 응답 검증
-        if (aiResult == null || aiResult.getAnswer() == null) {
-            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
-        }
-
-        // choices JSON 변환
-        String choicesJson = null;
-
-        if (aiResult.getChoices() != null) {
-
-            try {
-                choicesJson = objectMapper.writeValueAsString(aiResult.getChoices());
-            } catch (Exception e) {
-
-                throw new ApplicationException(
-                        ChatbotErrorCase.AI_RESPONSE_INVALID, e);
-            }
-        }
+        // AI 서버 호출 (트랜잭션 X)
+        AiChatResult aiResult = callAi(session, userId, guestId, request);
 
         // BOT 메시지 저장
-        ChatMessage savedBot =
-                chatMessageRepository.save(
-                        ChatMessage.createBot(
-                                sessionId,
-                                aiResult.getAnswer(),
-                                aiResult.getSafetyStatus(),
-                                choicesJson
-                        )
-                );
-
-        // lastMessageAt 업데이트
-        session.updateLastMessageAt(savedBot.getCreatedAt());
+        ChatMessage savedBot = saveBotMessage(session, aiResult);
 
         return ChatMessageSendResponse.builder()
                 .sessionId(sessionId)
@@ -133,19 +64,122 @@ public class ChatMessageService {
                 .build();
     }
 
-    private ChatMessageDto toDto(ChatMessage m) {
 
+    // 세션 조회 + 권한 체크
+    @Transactional(readOnly = true)
+    protected ChatSession loadSessionWithAuthCheck(
+            Long sessionId,
+            Long userId,
+            String guestId
+    ) {
+
+        ChatSession session =
+                chatSessionRepository.findById(sessionId)
+                        .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        boolean isOwner =
+                (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+
+        if (!isOwner) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        }
+
+        return session;
+    }
+
+
+    // USER 메시지 저장
+    @Transactional
+    protected ChatMessage saveUserMessage(
+            Long sessionId,
+            ChatMessageSendRequest request
+    ) {
+        MessageType type =
+                request.getMessageType() == null
+                        ? MessageType.TEXT
+                        : request.getMessageType();
+
+        return chatMessageRepository.save(
+                ChatMessage.createUser(
+                        sessionId,
+                        type,
+                        request.getMessage()
+                )
+        );
+    }
+
+
+    // AI 서버 호출
+    private AiChatResult callAi(
+            ChatSession session,
+            Long userId,
+            String guestId,
+            ChatMessageSendRequest request
+    ) {
+        Long personaId = session.getChatbotType().getId();
+
+        String requester = userId != null ? String.valueOf(userId) : guestId;
+
+        AiChatResult result =
+                aiChatClient.chat(
+                        AiChatCommand.builder()
+                                .userId(requester)
+                                .sessionId(session.getId())
+                                .personaId(personaId)
+                                .message(request.getMessage())
+                                .build()
+                );
+
+        if (result == null || result.getAnswer() == null) {
+            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+        }
+        return result;
+    }
+
+
+    // BOT 메시지 저장 + lastMessageAt 업데이트
+    @Transactional
+    protected ChatMessage saveBotMessage(
+            ChatSession session,
+            AiChatResult aiResult
+    ) {
+        String choicesJson = null;
+
+        if (aiResult.getChoices() != null) {
+            try {
+                choicesJson = objectMapper.writeValueAsString(aiResult.getChoices());
+            } catch (Exception e) {
+                throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID, e);
+            }
+        }
+
+        ChatMessage savedBot =
+                chatMessageRepository.save(
+                        ChatMessage.createBot(
+                                session.getId(),
+                                aiResult.getAnswer(),
+                                aiResult.getSafetyStatus(),
+                                choicesJson
+                        )
+                );
+
+        session.updateLastMessageAt(savedBot.getCreatedAt());
+        return savedBot;
+    }
+
+
+    // DTO 변환
+    private ChatMessageDto toDto(ChatMessage m) {
         List<String> choices = null;
 
-        if (m.getChoicesJson() != null && !m.getChoicesJson().isBlank()) {
+        if (m.getChoicesJson() != null
+                && !m.getChoicesJson().isBlank()) {
+
             try {
-                choices = objectMapper.readValue(
-                        m.getChoicesJson(),
-                        new TypeReference<List<String>>() {}
-                );
+                choices = objectMapper.readValue(m.getChoicesJson(), new TypeReference<List<String>>() {});
             } catch (Exception e) {
-                log.warn("choices JSON 역직렬화 실패: messageId={}", m.getId(), e);
-                choices = null;
+                log.warn("choices parse fail id={}", m.getId());
             }
         }
 
@@ -161,18 +195,20 @@ public class ChatMessageService {
                 .build();
     }
 
+
     // guestId 정규화
     private String normalizeGuestId(String guestIdHeader) {
 
         if (guestIdHeader == null) {
             return null;
         }
-
         String trimmed = guestIdHeader.trim();
 
         return trimmed.isEmpty() ? null : trimmed;
     }
 
+
+    // 로그인 userId 추출
     private Long extractUserIdIfAuthenticated() {
 
         var auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -1,0 +1,109 @@
+package com.wilo.server.chatbot.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wilo.server.chatbot.client.AiChatResult;
+import com.wilo.server.chatbot.dto.ChatMessageDto;
+import com.wilo.server.chatbot.dto.ChatMessageSendRequest;
+import com.wilo.server.chatbot.entity.ChatMessage;
+import com.wilo.server.chatbot.entity.ChatSession;
+import com.wilo.server.chatbot.entity.MessageType;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatMessageRepository;
+import com.wilo.server.chatbot.repository.ChatSessionRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessageTxService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public Long getPersonaIdWithAuthCheck(Long sessionId, Long userId, String guestId) {
+
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        boolean isOwner =
+                (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+
+        if (!isOwner) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        }
+
+        return session.getChatbotType().getId();
+    }
+
+    @Transactional
+    public ChatMessage saveUserMessage(Long sessionId, ChatMessageSendRequest request) {
+
+        MessageType type = (request.getMessageType() == null) ? MessageType.TEXT : request.getMessageType();
+
+        return chatMessageRepository.save(
+                ChatMessage.createUser(sessionId, type, request.getMessage())
+        );
+    }
+
+    @Transactional
+    public ChatMessage saveBotMessageWithSessionUpdate(Long sessionId, AiChatResult aiResult) {
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        String choicesJson = null;
+        if (aiResult.getChoices() != null) {
+            try {
+                choicesJson = objectMapper.writeValueAsString(aiResult.getChoices());
+            } catch (Exception e) {
+                throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID, e);
+            }
+        }
+
+        ChatMessage savedBot = chatMessageRepository.save(
+                ChatMessage.createBot(
+                        sessionId,
+                        aiResult.getAnswer(),
+                        aiResult.getSafetyStatus(),
+                        choicesJson
+                )
+        );
+
+        session.updateLastMessageAt(savedBot.getCreatedAt());
+
+        return savedBot;
+    }
+
+    public ChatMessageDto toDto(ChatMessage m) {
+
+        List<String> choices = null;
+
+        if (m.getChoicesJson() != null && !m.getChoicesJson().isBlank()) {
+            try {
+                choices = objectMapper.readValue(m.getChoicesJson(), new TypeReference<List<String>>() {});
+            } catch (Exception e) {
+                log.warn("파싱 실패 id={}", m.getId(), e);
+            }
+        }
+
+        return ChatMessageDto.builder()
+                .messageId(m.getId())
+                .senderType(m.getSenderType())
+                .messageType(m.getMessageType())
+                .content(m.getContent())
+                .createdAt(m.getCreatedAt())
+                .safetyStatus(m.getSafetyStatus())
+                .choices(choices)
+                .attachments(List.of())
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -31,12 +31,12 @@ public class ChatMessageTxService {
     @Transactional(readOnly = true)
     public Long getPersonaIdWithAuthCheck(Long sessionId, Long userId, String guestId) {
 
-        ChatSession session = chatSessionRepository.findById(sessionId)
+        ChatSession session = chatSessionRepository
+                .findByIdWithChatbotType(sessionId)
                 .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
 
-        boolean isOwner =
-                (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
-                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+        boolean isOwner = (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
 
         if (!isOwner) {
             throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -146,6 +146,10 @@ public class ChatSessionService {
         ChatSession session = chatSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
 
+        if (session.getStatus() == ChatSessionStatus.DELETED) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+
         boolean isOwner =
                 (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
                         || (userId == null && guestId != null && guestId.equals(session.getGuestId()));

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -130,6 +130,44 @@ public class ChatSessionService {
                 .build();
     }
 
+    @Transactional
+    public ChatSessionTitleUpdateResponse updateSessionTitle(
+            Long sessionId,
+            String guestIdHeader,
+            ChatSessionTitleUpdateRequest request
+    ) {
+        Long userId = extractUserIdIfAuthenticated();
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (userId == null && guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        boolean isOwner =
+                (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+
+        if (!isOwner) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        }
+
+        String title = request.getTitle().trim();
+
+        if (title.isBlank() || title.length() > 200) {
+            throw new ApplicationException(ChatbotErrorCase.TITLE_INVALID);
+        }
+
+        session.updateTitle(title);
+
+        return ChatSessionTitleUpdateResponse.builder()
+                .sessionId(session.getId())
+                .title(session.getTitle())
+                .build();
+    }
+
     private ChatSessionListItem toItem(ChatSession session) {
         String preview = session.getTitle();
 

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -168,6 +168,40 @@ public class ChatSessionService {
                 .build();
     }
 
+    @Transactional
+    public ChatSessionArchiveResponse archiveSession(
+            Long sessionId,
+            String guestIdHeader
+    ) {
+        Long userId = extractUserIdIfAuthenticated();
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (userId == null && guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        boolean isOwner = (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+
+        if (!isOwner) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        }
+
+        if (session.getStatus() == ChatSessionStatus.DELETED) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+
+        session.archive();
+
+        return ChatSessionArchiveResponse.builder()
+                .sessionId(session.getId())
+                .status(session.getStatus().name())
+                .build();
+    }
+
     private ChatSessionListItem toItem(ChatSession session) {
         String preview = session.getTitle();
 

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -202,6 +202,47 @@ public class ChatSessionService {
                 .build();
     }
 
+    @Transactional
+    public ChatSessionRestoreResponse restoreSession(
+            Long sessionId,
+            String guestIdHeader
+    ) {
+        Long userId = extractUserIdIfAuthenticated();
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (userId == null && guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() ->
+                        new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND)
+                );
+
+        boolean isOwner = (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+
+        if (!isOwner) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        }
+
+        if (session.getStatus() == ChatSessionStatus.DELETED) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+
+        if (session.getStatus() != ChatSessionStatus.ARCHIVED) {
+            // ACTIVE인데 restore 요청하면 400 처리
+            throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
+        }
+
+        session.restore();
+
+        return ChatSessionRestoreResponse.builder()
+                .sessionId(session.getId())
+                .status(session.getStatus().name())
+                .build();
+    }
+
     private ChatSessionListItem toItem(ChatSession session) {
         String preview = session.getTitle();
 

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -26,6 +26,9 @@ spring:
     console:
       enabled: false
 
+ai:
+  base-url: http://localhost:8000
+
 logging:
   level:
     root: warn

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -30,6 +30,8 @@ spring:
     console:
       enabled: false
 
+ai:
+  base-url: http://localhost:8000
 
 logging:
   level:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #24 

## 📝 작업 내용
**1. 메시지 전송 API 구현 (BE ↔ AI 연동 기반)**
- POST /api/v1/chat/messages
- 사용자 메시지 저장 → AI 서버 /chat 호출 → 봇 답변 저장 → 응답 반환 흐름 구현
- 비로그인/로그인 모두 지원
- 로그인: JWT에서 userId 사용, 비로그인: X-Guest-Id 헤더 기반 식별
- 봇 응답의 safetyStatus, choices(3) 처리 사용 
- choices는 JSON으로 저장하고 응답 시 List로 역직렬화

**2. 세션 제목 수정 API 구현**
- PATCH /api/v1/chat/sessions/{sessionId}
- 세션 소유자만 제목 변경 가능

**3. 세션 보관/복원 API 구현 (보관함 기능)**
- 보관: PATCH /api/v1/chat/sessions/{sessionId}/archive
- 복원: PATCH /api/v1/chat/sessions/{sessionId}/restore
- restore는 ARCHIVED → ACTIVE만 허용


## 🖼️ 스크린샷 (선택)

> 

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 세션 메시지 전송 흐름 추가(사용자 메시지 → AI 응답)
  * 세션 제목 수정 기능 추가(제목 검증 포함)
  * 세션 보관 및 복원 기능 추가
  * AI 응답 처리 강화(응답 본문, 안전성 표시 및 선택지 지원)
  * 비인증 게스트 지원(헤더 기반) 및 입력 유효성 강화(메시지 최대 4000자 등)
  * 새 REST 엔드포인트 추가: 메시지 전송 및 세션 제목/보관/복원용 PATCH API
<!-- end of auto-generated comment: release notes by coderabbit.ai -->