### PR TITLE
[FEAT] 게스트 용 프로필 생성,조회 및 게스트 닉네임,챗봇 유형 수정 API 구현 

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeItem.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeItem.java
@@ -12,7 +12,8 @@ public class ChatbotTypeItem {
     private String code;
     private String name;
     private String description;
-    private boolean isActive;
+    private String imageUrl;
+    private boolean active;
 
     public static ChatbotTypeItem from(ChatbotType type) {
         return ChatbotTypeItem.builder()
@@ -20,7 +21,8 @@ public class ChatbotTypeItem {
                 .code(type.getCode())
                 .name(type.getName())
                 .description(type.getDescription())
-                .isActive(type.isActive())
+                .imageUrl(type.getImageUrl())
+                .active(type.isActive())
                 .build();
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatbotType.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatbotType.java
@@ -24,6 +24,9 @@ public class ChatbotType {
     @Column(length = 255)
     private String description;
 
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
 }

--- a/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
+++ b/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
@@ -1,6 +1,8 @@
 package com.wilo.server.user.controller;
 
 import com.wilo.server.global.response.CommonResponse;
+import com.wilo.server.user.dto.GuestChatbotTypeSetRequestDto;
+import com.wilo.server.user.dto.GuestChatbotTypeSetResponseDto;
 import com.wilo.server.user.dto.GuestNicknameRequestDto;
 import com.wilo.server.user.dto.GuestNicknameResponseDto;
 import com.wilo.server.user.service.GuestProfileService;
@@ -45,4 +47,27 @@ public class GuestProfileController {
         return CommonResponse.success(guestProfileService.setNickname(guestId, request));
     }
 
+    @PostMapping("/chatbot-type")
+    @Operation(
+            summary = "비로그인(게스트) 챗봇 유형 설정",
+            description = """
+                    비로그인 사용자의 챗봇 유형을 설정합니다.
+                    - 게스트 식별자는 X-Guest-Id 헤더로 전달합니다.
+                    - chatbotTypeId는 /api/v1/chatbot-types 조회 결과의 id를 사용합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "설정 성공"),
+            @ApiResponse(responseCode = "400", description = "게스트 헤더 누락/요청값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 챗봇 유형",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<GuestChatbotTypeSetResponseDto> setGuestChatbotType(
+            @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
+            @Valid @RequestBody GuestChatbotTypeSetRequestDto request
+    ) {
+        return CommonResponse.success(guestProfileService.setChatbotType(guestId, request));
+    }
 }

--- a/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
+++ b/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
@@ -47,6 +47,27 @@ public class GuestProfileController {
         return CommonResponse.success(guestProfileService.createProfile(guestId, request));
     }
 
+    @GetMapping
+    @Operation(
+            summary = "게스트 프로필 조회",
+            description = """
+                비로그인 사용자의 프로필 정보를 조회합니다.
+                - X-Guest-Id 헤더 필수
+                - 프로필 없으면 profileExists=false 반환
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "게스트 헤더 누락",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<GuestProfileGetResponseDto> getProfile(
+            @Parameter(description = "비로그인 사용자 식별자(UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId
+    ) {
+        return CommonResponse.success(guestProfileService.getProfile(guestId));
+    }
+
     @PatchMapping("/nickname")
     @Operation(
             summary = "게스트 닉네임 수정",

--- a/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
+++ b/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
@@ -47,13 +47,12 @@ public class GuestProfileController {
         return CommonResponse.success(guestProfileService.createProfile(guestId, request));
     }
 
-    @PostMapping("/nickname")
+    @PatchMapping("/nickname")
     @Operation(
-            summary = "게스트 닉네임 설정",
+            summary = "게스트 닉네임 수정",
             description = """
-                    비로그인 사용자의 닉네임을 설정합니다.
-                    - X-Guest-Id 헤더 필수
-                    - 최초 호출 시 프로필 생성
+                    비로그인 사용자의 닉네임을 수정합니다.
+                    - X-Guest-Id 헤더 필수    
                     """
     )
     @ApiResponses(value = {
@@ -68,16 +67,15 @@ public class GuestProfileController {
             String guestId,
             @Valid @RequestBody GuestNicknameRequestDto request
     ) {
-        return CommonResponse.success(guestProfileService.setNickname(guestId, request));
+        return CommonResponse.success(guestProfileService.updateNickname(guestId, request));
     }
 
-    @PostMapping("/chatbot-type")
+    @PatchMapping("/chatbot-type")
     @Operation(
-            summary = "비로그인(게스트) 챗봇 유형 설정",
+            summary = "비로그인(게스트) 챗봇 유형 수정",
             description = """
-                    비로그인 사용자의 챗봇 유형을 설정합니다.
-                    - 게스트 식별자는 X-Guest-Id 헤더로 전달합니다.
-                    - chatbotTypeId는 /api/v1/chatbot-types 조회 결과의 id를 사용합니다.
+                    비로그인 사용자의 챗봇 유형을 수정합니다.
+                    - X-Guest-Id 헤더 필수
                     """
     )
     @ApiResponses(value = {
@@ -92,6 +90,6 @@ public class GuestProfileController {
             @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
             @Valid @RequestBody GuestChatbotTypeSetRequestDto request
     ) {
-        return CommonResponse.success(guestProfileService.setChatbotType(guestId, request));
+        return CommonResponse.success(guestProfileService.updateChatbotType(guestId, request));
     }
 }

--- a/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
+++ b/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
@@ -80,6 +80,9 @@ public class GuestProfileController {
             @ApiResponse(responseCode = "200", description = "닉네임 설정 성공"),
             @ApiResponse(responseCode = "400", description = "닉네임 정책 위반",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "게스트 프로필을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
             )
     })
     public CommonResponse<GuestNicknameResponseDto> setNickname(
@@ -103,7 +106,7 @@ public class GuestProfileController {
             @ApiResponse(responseCode = "200", description = "설정 성공"),
             @ApiResponse(responseCode = "400", description = "게스트 헤더 누락/요청값 검증 실패",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 챗봇 유형",
+            @ApiResponse(responseCode = "404", description = "게스트 프로필 미존재 또는 존재하지 않는 챗봇 유형",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<GuestChatbotTypeSetResponseDto> setGuestChatbotType(

--- a/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
+++ b/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
@@ -1,10 +1,7 @@
 package com.wilo.server.user.controller;
 
 import com.wilo.server.global.response.CommonResponse;
-import com.wilo.server.user.dto.GuestChatbotTypeSetRequestDto;
-import com.wilo.server.user.dto.GuestChatbotTypeSetResponseDto;
-import com.wilo.server.user.dto.GuestNicknameRequestDto;
-import com.wilo.server.user.dto.GuestNicknameResponseDto;
+import com.wilo.server.user.dto.*;
 import com.wilo.server.user.service.GuestProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,6 +19,33 @@ import org.springframework.web.bind.annotation.*;
 public class GuestProfileController {
 
     private final GuestProfileService guestProfileService;
+
+    @PostMapping
+    @Operation(
+            summary = "게스트 프로필 최초 생성",
+            description = """
+                게스트 프로필을 최초 생성합니다.
+                - X-Guest-Id 헤더 필수
+                - 닉네임과 챗봇 유형을 동시에 설정합니다.
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "닉네임 정책 위반",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 챗봇 유형",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            )
+    })
+    public CommonResponse<GuestProfileCreateResponseDto> createProfile(
+            @Parameter(description = "비로그인 사용자 식별자(UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false)
+            String guestId,
+            @Valid @RequestBody GuestProfileCreateRequestDto request
+    ) {
+        return CommonResponse.success(guestProfileService.createProfile(guestId, request));
+    }
 
     @PostMapping("/nickname")
     @Operation(

--- a/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
+++ b/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
@@ -40,7 +40,7 @@ public class GuestProfileController {
     })
     public CommonResponse<GuestProfileCreateResponseDto> createProfile(
             @Parameter(description = "비로그인 사용자 식별자(UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
-            @RequestHeader(value = "X-Guest-Id", required = false)
+            @RequestHeader(value = "X-Guest-Id")
             String guestId,
             @Valid @RequestBody GuestProfileCreateRequestDto request
     ) {

--- a/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
+++ b/src/main/java/com/wilo/server/user/controller/GuestProfileController.java
@@ -1,0 +1,48 @@
+package com.wilo.server.user.controller;
+
+import com.wilo.server.global.response.CommonResponse;
+import com.wilo.server.user.dto.GuestNicknameRequestDto;
+import com.wilo.server.user.dto.GuestNicknameResponseDto;
+import com.wilo.server.user.service.GuestProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/guest/profile")
+public class GuestProfileController {
+
+    private final GuestProfileService guestProfileService;
+
+    @PostMapping("/nickname")
+    @Operation(
+            summary = "게스트 닉네임 설정",
+            description = """
+                    비로그인 사용자의 닉네임을 설정합니다.
+                    - X-Guest-Id 헤더 필수
+                    - 최초 호출 시 프로필 생성
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 설정 성공"),
+            @ApiResponse(responseCode = "400", description = "닉네임 정책 위반",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            )
+    })
+    public CommonResponse<GuestNicknameResponseDto> setNickname(
+            @Parameter(description = "비로그인 사용자 식별자(UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false)
+            String guestId,
+            @Valid @RequestBody GuestNicknameRequestDto request
+    ) {
+        return CommonResponse.success(guestProfileService.setNickname(guestId, request));
+    }
+
+}

--- a/src/main/java/com/wilo/server/user/dto/GuestChatbotTypeSetRequestDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestChatbotTypeSetRequestDto.java
@@ -1,0 +1,15 @@
+package com.wilo.server.user.dto;
+
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class GuestChatbotTypeSetRequestDto {
+    @NotNull(message = "chatbotTypeId는 필수입니다.")
+    @Positive(message = "chatbotTypeId는 양수여야 합니다.")
+    private Long chatbotTypeId;
+}

--- a/src/main/java/com/wilo/server/user/dto/GuestChatbotTypeSetResponseDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestChatbotTypeSetResponseDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @Builder
 public class GuestChatbotTypeSetResponseDto {
-    private String chatbotTypeId;
+    private Long chatbotTypeId;
 }

--- a/src/main/java/com/wilo/server/user/dto/GuestChatbotTypeSetResponseDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestChatbotTypeSetResponseDto.java
@@ -1,0 +1,10 @@
+package com.wilo.server.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GuestChatbotTypeSetResponseDto {
+    private String chatbotTypeId;
+}

--- a/src/main/java/com/wilo/server/user/dto/GuestNicknameRequestDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestNicknameRequestDto.java
@@ -1,0 +1,10 @@
+package com.wilo.server.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class GuestNicknameRequestDto {
+    @NotBlank
+    private String nickname;
+}

--- a/src/main/java/com/wilo/server/user/dto/GuestNicknameRequestDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestNicknameRequestDto.java
@@ -1,10 +1,12 @@
 package com.wilo.server.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class GuestNicknameRequestDto {
     @NotBlank
+    @Size(max = 20, message = "nickname은 최대 20자까지 가능합니다.")
     private String nickname;
 }

--- a/src/main/java/com/wilo/server/user/dto/GuestNicknameResponseDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestNicknameResponseDto.java
@@ -1,0 +1,11 @@
+package com.wilo.server.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GuestNicknameResponseDto {
+    private String guestId;
+    private String nickname;
+}

--- a/src/main/java/com/wilo/server/user/dto/GuestProfileCreateRequestDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestProfileCreateRequestDto.java
@@ -2,12 +2,15 @@ package com.wilo.server.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class GuestProfileCreateRequestDto {
     @NotBlank
+    @Size(max = 20, message = "nickname은 최대 20자까지 가능합니다.")
     private String nickname;
-    @NotNull
+    @NotNull @Positive
     private Long chatbotTypeId;
 }

--- a/src/main/java/com/wilo/server/user/dto/GuestProfileCreateRequestDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestProfileCreateRequestDto.java
@@ -1,0 +1,13 @@
+package com.wilo.server.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class GuestProfileCreateRequestDto {
+    @NotBlank
+    private String nickname;
+    @NotNull
+    private Long chatbotTypeId;
+}

--- a/src/main/java/com/wilo/server/user/dto/GuestProfileCreateResponseDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestProfileCreateResponseDto.java
@@ -1,0 +1,12 @@
+package com.wilo.server.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GuestProfileCreateResponseDto {
+    private String guestId;
+    private String nickname;
+    private Long chatbotTypeId;
+}

--- a/src/main/java/com/wilo/server/user/dto/GuestProfileGetResponseDto.java
+++ b/src/main/java/com/wilo/server/user/dto/GuestProfileGetResponseDto.java
@@ -1,0 +1,13 @@
+package com.wilo.server.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GuestProfileGetResponseDto {
+    private String guestId;
+    private String nickname;
+    private Long chatbotTypeId;
+    private boolean profileExists;
+}

--- a/src/main/java/com/wilo/server/user/entity/GuestProfile.java
+++ b/src/main/java/com/wilo/server/user/entity/GuestProfile.java
@@ -23,14 +23,22 @@ public class GuestProfile extends BaseEntity {
     private String nickname;
 
 
-    public static GuestProfile create(String guestId){
-        GuestProfile g = new GuestProfile();
-        g.guestId = guestId;
-        return g;
+    @Column(name = "chatbot_type_id")
+    private Long chatbotTypeId;
+
+    public static GuestProfile create(String guestId) {
+        GuestProfile p = new GuestProfile();
+        p.guestId = guestId;
+        p.nickname = null;
+        p.chatbotTypeId = null;
+        return p;
     }
 
-    public void updateNickname(String nickname){
+    public void updateChatbotTypeId(Long chatbotTypeId) {
+        this.chatbotTypeId = chatbotTypeId;
+    }
+
+    public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
-
 }

--- a/src/main/java/com/wilo/server/user/entity/GuestProfile.java
+++ b/src/main/java/com/wilo/server/user/entity/GuestProfile.java
@@ -1,0 +1,36 @@
+package com.wilo.server.user.entity;
+
+import com.wilo.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "guest_profiles")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GuestProfile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="guest_id", nullable=false, unique=true)
+    private String guestId;
+
+    @Column(length=20)
+    private String nickname;
+
+
+    public static GuestProfile create(String guestId){
+        GuestProfile g = new GuestProfile();
+        g.guestId = guestId;
+        return g;
+    }
+
+    public void updateNickname(String nickname){
+        this.nickname = nickname;
+    }
+
+}

--- a/src/main/java/com/wilo/server/user/error/UserErrorCase.java
+++ b/src/main/java/com/wilo/server/user/error/UserErrorCase.java
@@ -11,7 +11,8 @@ public enum UserErrorCase implements ErrorCase {
     USER_NOT_FOUND(404, 3001, "유저를 찾을 수 없습니다."),
     NICKNAME_ALREADY_EXISTS(409, 3002, "이미 사용 중인 닉네임입니다."),
     INVALID_NICKNAME(400, 3003, "닉네임이 정책을 충족하지 않습니다."),
-    GUEST_PROFILE_NOT_FOUND(404,3004,"게스트 프로필을 찾을 수 없습니다.");
+    GUEST_PROFILE_NOT_FOUND(404,3004,"게스트 프로필을 찾을 수 없습니다."),
+    INVALID_GUEST_ID(400,3005,"게스트 ID의 형식이 올바르지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/user/error/UserErrorCase.java
+++ b/src/main/java/com/wilo/server/user/error/UserErrorCase.java
@@ -10,7 +10,8 @@ public enum UserErrorCase implements ErrorCase {
 
     USER_NOT_FOUND(404, 3001, "유저를 찾을 수 없습니다."),
     NICKNAME_ALREADY_EXISTS(409, 3002, "이미 사용 중인 닉네임입니다."),
-    INVALID_NICKNAME(400, 3003, "닉네임이 정책을 충족하지 않습니다.");
+    INVALID_NICKNAME(400, 3003, "닉네임이 정책을 충족하지 않습니다."),
+    GUEST_PROFILE_NOT_FOUND(404,3004,"게스트 프로필을 찾을 수 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/user/error/UserErrorCase.java
+++ b/src/main/java/com/wilo/server/user/error/UserErrorCase.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCase implements ErrorCase {
 
     USER_NOT_FOUND(404, 3001, "유저를 찾을 수 없습니다."),
-    NICKNAME_ALREADY_EXISTS(409, 3002, "이미 사용 중인 닉네임입니다.");
+    NICKNAME_ALREADY_EXISTS(409, 3002, "이미 사용 중인 닉네임입니다."),
+    INVALID_NICKNAME(400, 3003, "닉네임이 정책을 충족하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/user/repository/GuestProfileRepository.java
+++ b/src/main/java/com/wilo/server/user/repository/GuestProfileRepository.java
@@ -1,0 +1,10 @@
+package com.wilo.server.user.repository;
+
+import com.wilo.server.user.entity.GuestProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GuestProfileRepository extends JpaRepository<GuestProfile, Long> {
+    Optional<GuestProfile> findByGuestId(String guestId);
+}

--- a/src/main/java/com/wilo/server/user/service/GuestProfileService.java
+++ b/src/main/java/com/wilo/server/user/service/GuestProfileService.java
@@ -86,6 +86,5 @@ public class GuestProfileService {
         if (nickname.length() > 20) {
             throw new ApplicationException(UserErrorCase.INVALID_NICKNAME);
         }
-
     }
 }

--- a/src/main/java/com/wilo/server/user/service/GuestProfileService.java
+++ b/src/main/java/com/wilo/server/user/service/GuestProfileService.java
@@ -3,10 +3,7 @@ package com.wilo.server.user.service;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
 import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
 import com.wilo.server.global.exception.ApplicationException;
-import com.wilo.server.user.dto.GuestChatbotTypeSetRequestDto;
-import com.wilo.server.user.dto.GuestChatbotTypeSetResponseDto;
-import com.wilo.server.user.dto.GuestNicknameRequestDto;
-import com.wilo.server.user.dto.GuestNicknameResponseDto;
+import com.wilo.server.user.dto.*;
 import com.wilo.server.user.entity.GuestProfile;
 import com.wilo.server.user.error.UserErrorCase;
 import com.wilo.server.user.repository.GuestProfileRepository;
@@ -67,6 +64,36 @@ public class GuestProfileService {
         profile.updateChatbotTypeId(chatbotType.getId());
 
         return GuestChatbotTypeSetResponseDto.builder()
+                .chatbotTypeId(profile.getChatbotTypeId())
+                .build();
+    }
+
+    public GuestProfileCreateResponseDto createProfile(
+            String guestIdHeader,
+            GuestProfileCreateRequestDto request
+    ) {
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        validateNickname(request.getNickname());
+
+        var chatbotType = chatbotTypeRepository.findById(request.getChatbotTypeId())
+                .filter(type -> type.isActive())
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.CHATBOT_TYPE_NOT_FOUND));
+
+        GuestProfile profile =
+                guestProfileRepository.findByGuestId(guestId)
+                        .orElseGet(() -> guestProfileRepository.save(GuestProfile.create(guestId)));
+
+        profile.updateNickname(request.getNickname());
+        profile.updateChatbotTypeId(chatbotType.getId());
+
+        return GuestProfileCreateResponseDto.builder()
+                .guestId(profile.getGuestId())
+                .nickname(profile.getNickname())
                 .chatbotTypeId(profile.getChatbotTypeId())
                 .build();
     }

--- a/src/main/java/com/wilo/server/user/service/GuestProfileService.java
+++ b/src/main/java/com/wilo/server/user/service/GuestProfileService.java
@@ -19,55 +19,6 @@ public class GuestProfileService {
     private final GuestProfileRepository guestProfileRepository;
     private final ChatbotTypeRepository chatbotTypeRepository;
 
-
-    public GuestNicknameResponseDto setNickname(
-            String guestIdHeader,
-            GuestNicknameRequestDto request
-    ) {
-        String guestId = normalizeGuestId(guestIdHeader);
-
-        if (guestId == null) {
-            throw new ApplicationException(
-                    ChatbotErrorCase.GUEST_ID_REQUIRED
-            );
-        }
-
-        validateNickname(request.getNickname());
-
-        GuestProfile profile = guestProfileRepository.findByGuestId(guestId).orElseGet(() -> guestProfileRepository.save(GuestProfile.create(guestId)));
-
-        profile.updateNickname(request.getNickname());
-
-        return GuestNicknameResponseDto.builder()
-                .guestId(guestId)
-                .nickname(profile.getNickname())
-                .build();
-    }
-
-    public GuestChatbotTypeSetResponseDto setChatbotType(
-            String guestIdHeader,
-            GuestChatbotTypeSetRequestDto request
-    ) {
-        String guestId = normalizeGuestId(guestIdHeader);
-
-        if (guestId == null) {
-            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
-        }
-
-        var chatbotType = chatbotTypeRepository.findById(request.getChatbotTypeId())
-                .filter(type -> type.isActive())
-                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.CHATBOT_TYPE_NOT_FOUND));
-
-        GuestProfile profile = guestProfileRepository.findByGuestId(guestId)
-                .orElseGet(() -> guestProfileRepository.save(GuestProfile.create(guestId)));
-
-        profile.updateChatbotTypeId(chatbotType.getId());
-
-        return GuestChatbotTypeSetResponseDto.builder()
-                .chatbotTypeId(profile.getChatbotTypeId())
-                .build();
-    }
-
     public GuestProfileCreateResponseDto createProfile(
             String guestIdHeader,
             GuestProfileCreateRequestDto request
@@ -94,6 +45,54 @@ public class GuestProfileService {
         return GuestProfileCreateResponseDto.builder()
                 .guestId(profile.getGuestId())
                 .nickname(profile.getNickname())
+                .chatbotTypeId(profile.getChatbotTypeId())
+                .build();
+    }
+
+    public GuestNicknameResponseDto updateNickname(
+            String guestIdHeader,
+            GuestNicknameRequestDto request
+    ) {
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        validateNickname(request.getNickname());
+
+        GuestProfile profile =
+                guestProfileRepository.findByGuestId(guestId)
+                        .orElseThrow(() -> new ApplicationException(UserErrorCase.GUEST_PROFILE_NOT_FOUND));
+
+        profile.updateNickname(request.getNickname());
+
+        return GuestNicknameResponseDto.builder()
+                .guestId(guestId)
+                .nickname(profile.getNickname())
+                .build();
+    }
+
+    public GuestChatbotTypeSetResponseDto updateChatbotType(
+            String guestIdHeader,
+            GuestChatbotTypeSetRequestDto request
+    ) {
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        var chatbotType = chatbotTypeRepository.findById(request.getChatbotTypeId())
+                .filter(type -> type.isActive())
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.CHATBOT_TYPE_NOT_FOUND));
+
+        GuestProfile profile = guestProfileRepository.findByGuestId(guestId)
+                        .orElseThrow(() -> new ApplicationException(UserErrorCase.GUEST_PROFILE_NOT_FOUND));
+
+        profile.updateChatbotTypeId(chatbotType.getId());
+
+        return GuestChatbotTypeSetResponseDto.builder()
                 .chatbotTypeId(profile.getChatbotTypeId())
                 .build();
     }

--- a/src/main/java/com/wilo/server/user/service/GuestProfileService.java
+++ b/src/main/java/com/wilo/server/user/service/GuestProfileService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -126,7 +128,14 @@ public class GuestProfileService {
     private String normalizeGuestId(String guestIdHeader) {
         if (guestIdHeader == null) return null;
         String trimmed = guestIdHeader.trim();
-        return trimmed.isEmpty() ? null : trimmed;
+        if (trimmed.isEmpty()) return null;
+
+        try {
+            UUID.fromString(trimmed);  // UUID 형식 검증
+            return trimmed;
+        } catch (IllegalArgumentException e) {
+            throw new ApplicationException(UserErrorCase.INVALID_GUEST_ID);
+        }
     }
 
     private void validateNickname(String nickname) {

--- a/src/main/java/com/wilo/server/user/service/GuestProfileService.java
+++ b/src/main/java/com/wilo/server/user/service/GuestProfileService.java
@@ -1,0 +1,69 @@
+package com.wilo.server.user.service;
+
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.global.exception.ApplicationException;
+import com.wilo.server.user.dto.GuestNicknameRequestDto;
+import com.wilo.server.user.dto.GuestNicknameResponseDto;
+import com.wilo.server.user.entity.GuestProfile;
+import com.wilo.server.user.error.UserErrorCase;
+import com.wilo.server.user.repository.GuestProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GuestProfileService {
+
+    private final GuestProfileRepository guestProfileRepository;
+
+
+    public GuestNicknameResponseDto setNickname(
+            String guestIdHeader,
+            GuestNicknameRequestDto request
+    ) {
+
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (guestId == null) {
+            throw new ApplicationException(
+                    ChatbotErrorCase.GUEST_ID_REQUIRED
+            );
+        }
+
+        validateNickname(request.getNickname());
+
+        GuestProfile profile = guestProfileRepository.findByGuestId(guestId).orElseGet(() -> guestProfileRepository.save(GuestProfile.create(guestId)));
+
+        profile.updateNickname(request.getNickname());
+
+        return GuestNicknameResponseDto.builder()
+                .guestId(guestId)
+                .nickname(profile.getNickname())
+                .build();
+    }
+
+
+    private void validateNickname(String nickname) {
+
+        if (nickname == null || nickname.isBlank()) {
+            throw new ApplicationException(UserErrorCase.INVALID_NICKNAME);
+        }
+
+        if (nickname.length() > 20) {
+            throw new ApplicationException(UserErrorCase.INVALID_NICKNAME);
+        }
+
+    }
+
+
+    private String normalizeGuestId(String guestIdHeader) {
+        if (guestIdHeader == null) return null;
+
+        String trimmed = guestIdHeader.trim();
+
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+}

--- a/src/main/java/com/wilo/server/user/service/GuestProfileService.java
+++ b/src/main/java/com/wilo/server/user/service/GuestProfileService.java
@@ -49,6 +49,32 @@ public class GuestProfileService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
+    public GuestProfileGetResponseDto getProfile(String guestIdHeader) {
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        return guestProfileRepository.findByGuestId(guestId)
+                .map(profile ->
+                        GuestProfileGetResponseDto.builder()
+                                .guestId(guestId)
+                                .nickname(profile.getNickname())
+                                .chatbotTypeId(profile.getChatbotTypeId())
+                                .profileExists(true)
+                                .build()
+                )
+                .orElse(GuestProfileGetResponseDto.builder()
+                                .guestId(guestId)
+                                .nickname(null)
+                                .chatbotTypeId(null)
+                                .profileExists(false)
+                                .build()
+                );
+    }
+
     public GuestNicknameResponseDto updateNickname(
             String guestIdHeader,
             GuestNicknameRequestDto request

--- a/src/main/java/com/wilo/server/user/service/GuestProfileService.java
+++ b/src/main/java/com/wilo/server/user/service/GuestProfileService.java
@@ -1,7 +1,10 @@
 package com.wilo.server.user.service;
 
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
 import com.wilo.server.global.exception.ApplicationException;
+import com.wilo.server.user.dto.GuestChatbotTypeSetRequestDto;
+import com.wilo.server.user.dto.GuestChatbotTypeSetResponseDto;
 import com.wilo.server.user.dto.GuestNicknameRequestDto;
 import com.wilo.server.user.dto.GuestNicknameResponseDto;
 import com.wilo.server.user.entity.GuestProfile;
@@ -17,13 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class GuestProfileService {
 
     private final GuestProfileRepository guestProfileRepository;
+    private final ChatbotTypeRepository chatbotTypeRepository;
 
 
     public GuestNicknameResponseDto setNickname(
             String guestIdHeader,
             GuestNicknameRequestDto request
     ) {
-
         String guestId = normalizeGuestId(guestIdHeader);
 
         if (guestId == null) {
@@ -44,6 +47,35 @@ public class GuestProfileService {
                 .build();
     }
 
+    public GuestChatbotTypeSetResponseDto setChatbotType(
+            String guestIdHeader,
+            GuestChatbotTypeSetRequestDto request
+    ) {
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        var chatbotType = chatbotTypeRepository.findById(request.getChatbotTypeId())
+                .filter(type -> type.isActive())
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.CHATBOT_TYPE_NOT_FOUND));
+
+        GuestProfile profile = guestProfileRepository.findByGuestId(guestId)
+                .orElseGet(() -> guestProfileRepository.save(GuestProfile.create(guestId)));
+
+        profile.updateChatbotTypeId(chatbotType.getId());
+
+        return GuestChatbotTypeSetResponseDto.builder()
+                .chatbotTypeId(profile.getChatbotTypeId())
+                .build();
+    }
+
+    private String normalizeGuestId(String guestIdHeader) {
+        if (guestIdHeader == null) return null;
+        String trimmed = guestIdHeader.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
 
     private void validateNickname(String nickname) {
 
@@ -56,14 +88,4 @@ public class GuestProfileService {
         }
 
     }
-
-
-    private String normalizeGuestId(String guestIdHeader) {
-        if (guestIdHeader == null) return null;
-
-        String trimmed = guestIdHeader.trim();
-
-        return trimmed.isEmpty() ? null : trimmed;
-    }
-
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #27 

## 📝 작업 내용
```
POST   /api/v1/guest/profile
GET    /api/v1/guest/profile
PATCH  /api/v1/guest/profile/nickname
PATCH  /api/v1/guest/profile/chatbot-type
```
해당 API 구현 및 프론트 요구사항 반영으로 챗봇 유형 목록 조회에 이미지 url 추가하였습니다. 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게스트 프로필 관리 기능 추가: 프로필 생성·조회·닉네임 변경·챗봇 타입 설정 API 제공
  * 게스트용 요청/응답 DTO와 영속화 엔티티, 저장소 및 서비스 로직 추가

* **개선 사항**
  * 챗봇 타입에 이미지 URL 및 활성 여부 필드 추가(공개 데이터 형식 변경)
  * 닉네임 정책 검증 강화 및 게스트 관련 오류 코드 추가 (유효하지 않은 닉네임/게스트 ID/프로필 없음)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->