### PR TITLE
[FEAT] AI 채팅 연동 1차 구현 + 메시지 전송 API 구현 완료

### DIFF
--- a/src/main/java/com/wilo/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/wilo/server/auth/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/auth/**").permitAll()
                                 .requestMatchers("/api/v1/chatbot-types/**").permitAll()
                                 .requestMatchers("/api/v1/chat/**").permitAll()
+                                .requestMatchers("/api/v1/guest/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(sessionManagement ->
@@ -75,7 +76,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowedOriginPatterns(List.of("*")); // ✅ 모든 도메인에서 접근 가능
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // ✅ 허용할 HTTP 메서드
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")); // ✅ 허용할 HTTP 메서드
         config.setAllowedHeaders(List.of("*")); // ✅ 모든 헤더 허용
         config.setAllowCredentials(true); // ✅ 인증 정보 포함 요청 허용 (JWT 포함)
 

--- a/src/main/java/com/wilo/server/chatbot/client/AiChatCommand.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiChatCommand.java
@@ -1,13 +1,23 @@
 package com.wilo.server.chatbot.client;
 
+import com.wilo.server.chatbot.client.dto.AiRoleMessage;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
 
 @Getter
 @Builder
 public class AiChatCommand {
-    private String userId;      // userId or guestId 문자열
+    private String requestId;
+    private String userId;
     private Long sessionId;
-    private Long personaId;     // chatbotTypeId
+
+    private String personaId; // "EUNHAENG" | "BUDDLE" | "NEUTY"
     private String message;
+
+    private String sessionSummary;            // context.session_summary
+    private List<AiRoleMessage> recentMessages; // context.recent_messages
+    private Map<String, Object> memory;
 }

--- a/src/main/java/com/wilo/server/chatbot/client/AiClientConfig.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiClientConfig.java
@@ -15,18 +15,16 @@ import java.time.Duration;
 public class AiClientConfig {
     @Bean
     public WebClient aiWebClient(
-            @Value("${ai.base-url:http://localhost:8000}")
-            String baseUrl
+            @Value("${ai.base-url:http://15.134.128.31:8000}") String baseUrl
     ) {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
                 .responseTimeout(Duration.ofSeconds(30));
+
         return WebClient.builder()
                 .baseUrl(baseUrl)
-                .clientConnector(new ReactorClientHttpConnector(HttpClient.create().responseTimeout(Duration.ofSeconds(5))))
-                .codecs(configurer -> configurer
-                        .defaultCodecs()
-                        .maxInMemorySize(1024 * 1024))
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(c -> c.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
                 .build();
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/client/AiSafetyMapper.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiSafetyMapper.java
@@ -1,0 +1,17 @@
+package com.wilo.server.chatbot.client;
+
+import com.wilo.server.chatbot.entity.SafetyStatus;
+
+public class AiSafetyMapper {
+    private AiSafetyMapper() {}
+
+    public static SafetyStatus toBackend(String safetyStatus) {
+        if (safetyStatus == null) return null;
+        return switch (safetyStatus.toLowerCase()) {
+            case "clear" -> SafetyStatus.SAFE;
+            case "monitor", "caution" -> SafetyStatus.WARNING;
+            case "crisis" -> SafetyStatus.CRITICAL;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/client/AiSummarizeClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiSummarizeClient.java
@@ -1,0 +1,9 @@
+package com.wilo.server.chatbot.client;
+
+import com.wilo.server.chatbot.client.dto.AiRoleMessage;
+
+import java.util.List;
+
+public interface AiSummarizeClient {
+    AiSummarizeResult summarize(List<AiRoleMessage> messages);
+}

--- a/src/main/java/com/wilo/server/chatbot/client/AiSummarizeResult.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiSummarizeResult.java
@@ -1,0 +1,13 @@
+package com.wilo.server.chatbot.client;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AiSummarizeResult {
+    private String summary;
+    private List<String> keyTopics;
+}

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
@@ -52,8 +52,15 @@ public class RealAiChatClient implements AiChatClient {
                 )
                 .onStatus(
                         s -> s.is4xxClientError(),
-                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID)
-                        )
+                        r -> r.bodyToMono(String.class)
+                                .flatMap(body -> {
+                                    System.out.println("AI ERROR BODY = " + body);
+                                    return Mono.error(
+                                            new ApplicationException(
+                                                    ChatbotErrorCase.AI_RESPONSE_INVALID
+                                            )
+                                    );
+                                })
                 )
                 .bodyToMono(AiChatResponse.class)
                 .timeout(Duration.ofSeconds(35))

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
@@ -2,10 +2,10 @@ package com.wilo.server.chatbot.client;
 
 import com.wilo.server.chatbot.client.dto.AiChatRequest;
 import com.wilo.server.chatbot.client.dto.AiChatResponse;
-import com.wilo.server.chatbot.entity.SafetyStatus;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
 import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RealAiChatClient implements AiChatClient {
@@ -26,17 +27,17 @@ public class RealAiChatClient implements AiChatClient {
 
         AiChatRequest.Context context =
                 AiChatRequest.Context.builder()
-                        .recent_messages(command.getRecentMessages() == null ? List.of() : command.getRecentMessages())
-                        .session_summary(command.getSessionSummary() == null ? "" : command.getSessionSummary())
+                        .recentMessages(command.getRecentMessages() == null ? List.of() : command.getRecentMessages())
+                        .sessionSummary(command.getSessionSummary() == null ? "" : command.getSessionSummary())
                         .memory(command.getMemory() == null ? Map.of() : command.getMemory())
                         .build();
 
 
         AiChatRequest req = AiChatRequest.builder()
-                .request_id(command.getRequestId())
-                .user_id(command.getUserId())
-                .session_id(String.valueOf(command.getSessionId()))
-                .persona_id(command.getPersonaId())
+                .requestId(command.getRequestId())
+                .userId(command.getUserId())
+                .sessionId(String.valueOf(command.getSessionId()))
+                .personaId(command.getPersonaId())
                 .message(command.getMessage())
                 .context(context)
                 .build();
@@ -54,12 +55,8 @@ public class RealAiChatClient implements AiChatClient {
                         s -> s.is4xxClientError(),
                         r -> r.bodyToMono(String.class)
                                 .flatMap(body -> {
-                                    System.out.println("AI ERROR BODY = " + body);
-                                    return Mono.error(
-                                            new ApplicationException(
-                                                    ChatbotErrorCase.AI_RESPONSE_INVALID
-                                            )
-                                    );
+                                    log.warn("AI chat 4xx from upstream. requestId={}, status={}", command.getRequestId(), r.statusCode());
+                                    return Mono.error(new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID));
                                 })
                 )
                 .bodyToMono(AiChatResponse.class)
@@ -84,7 +81,7 @@ public class RealAiChatClient implements AiChatClient {
                 .sessionId(command.getSessionId())
                 .answer(res.getAnswer())
                 .choices(res.getChoices() == null ? List.of() : res.getChoices())
-                .safetyStatus(AiSafetyMapper.toBackend(res.getSafety_status()))
+                .safetyStatus(AiSafetyMapper.toBackend(res.getSafetyStatus()))
                 .build();
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
@@ -13,6 +13,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -23,42 +24,47 @@ public class RealAiChatClient implements AiChatClient {
     @Override
     public AiChatResult chat(AiChatCommand command) {
 
+        AiChatRequest.Context context =
+                AiChatRequest.Context.builder()
+                        .recent_messages(command.getRecentMessages() == null ? List.of() : command.getRecentMessages())
+                        .session_summary(command.getSessionSummary() == null ? "" : command.getSessionSummary())
+                        .memory(command.getMemory() == null ? Map.of() : command.getMemory())
+                        .build();
+
+
         AiChatRequest req = AiChatRequest.builder()
                 .request_id(command.getRequestId())
                 .user_id(command.getUserId())
                 .session_id(String.valueOf(command.getSessionId()))
                 .persona_id(command.getPersonaId())
                 .message(command.getMessage())
-                .context(AiChatRequest.Context.builder()
-                        .recent_messages(command.getRecentMessages())
-                        .session_summary(command.getSessionSummary())
-                        .memory(command.getMemory())
-                        .build())
+                .context(context)
                 .build();
+
 
         AiChatResponse res = aiWebClient.post()
                 .uri("/chat")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(req)
                 .retrieve()
-                .onStatus(
-                        s -> s.value() == 502 || s.value() == 503 || s.value() == 504,
+                .onStatus(s -> s.value() == 502 || s.value() == 503 || s.value() == 504,
                         r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED))
                 )
                 .onStatus(
                         s -> s.is4xxClientError(),
-                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID))
+                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID)
+                        )
                 )
                 .bodyToMono(AiChatResponse.class)
                 .timeout(Duration.ofSeconds(35))
                 .block();
 
+
         if (res == null) {
             throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
         }
 
-        // AI 내부 status 기반 실패 처리
-        if (res.getStatus() != null && !"success".equalsIgnoreCase(res.getStatus())) {
+        if (!"success".equalsIgnoreCase(res.getStatus())) {
             throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
         }
 
@@ -66,18 +72,12 @@ public class RealAiChatClient implements AiChatClient {
             throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
         }
 
-        List<String> choices = res.getChoices();
-        if (choices == null) {
-            choices = List.of();
-        }
-
-        SafetyStatus safety = AiSafetyMapper.toBackend(res.getSafety_status());
 
         return AiChatResult.builder()
                 .sessionId(command.getSessionId())
                 .answer(res.getAnswer())
-                .choices(choices)
-                .safetyStatus(safety)
+                .choices(res.getChoices() == null ? List.of() : res.getChoices())
+                .safetyStatus(AiSafetyMapper.toBackend(res.getSafety_status()))
                 .build();
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiChatClient.java
@@ -1,13 +1,18 @@
 package com.wilo.server.chatbot.client;
 
+import com.wilo.server.chatbot.client.dto.AiChatRequest;
+import com.wilo.server.chatbot.client.dto.AiChatResponse;
+import com.wilo.server.chatbot.entity.SafetyStatus;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
 import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
-import java.util.Map;
+import java.time.Duration;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -17,33 +22,62 @@ public class RealAiChatClient implements AiChatClient {
 
     @Override
     public AiChatResult chat(AiChatCommand command) {
-        try {
-            Map<String, Object> body = Map.of(
-                    "user_id", command.getUserId(),
-                    "session_id", command.getSessionId(),
-                    "persona_id", command.getPersonaId(),
-                    "message", command.getMessage()
-            );
 
-            // AI 서버 응답도 Map으로 먼저 받고, 백엔드에서 파싱
-            Map<String, Object> res = aiWebClient.post()
-                    .uri("/chat")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(body)
-                    .retrieve()
-                    .bodyToMono(Map.class)
-                    .block();
+        AiChatRequest req = AiChatRequest.builder()
+                .request_id(command.getRequestId())
+                .user_id(command.getUserId())
+                .session_id(String.valueOf(command.getSessionId()))
+                .persona_id(command.getPersonaId())
+                .message(command.getMessage())
+                .context(AiChatRequest.Context.builder()
+                        .recent_messages(command.getRecentMessages())
+                        .session_summary(command.getSessionSummary())
+                        .memory(command.getMemory())
+                        .build())
+                .build();
 
-            if (res == null) {
-                throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
-            }
+        AiChatResponse res = aiWebClient.post()
+                .uri("/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(req)
+                .retrieve()
+                .onStatus(
+                        s -> s.value() == 502 || s.value() == 503 || s.value() == 504,
+                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED))
+                )
+                .onStatus(
+                        s -> s.is4xxClientError(),
+                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID))
+                )
+                .bodyToMono(AiChatResponse.class)
+                .timeout(Duration.ofSeconds(35))
+                .block();
 
-            return AiResponseMapper.toResult(res);
-
-        } catch (ApplicationException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED, e);
+        if (res == null) {
+            throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
         }
+
+        // AI 내부 status 기반 실패 처리
+        if (res.getStatus() != null && !"success".equalsIgnoreCase(res.getStatus())) {
+            throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
+        }
+
+        if (res.getAnswer() == null || res.getAnswer().isBlank()) {
+            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+        }
+
+        List<String> choices = res.getChoices();
+        if (choices == null) {
+            choices = List.of();
+        }
+
+        SafetyStatus safety = AiSafetyMapper.toBackend(res.getSafety_status());
+
+        return AiChatResult.builder()
+                .sessionId(command.getSessionId())
+                .answer(res.getAnswer())
+                .choices(choices)
+                .safetyStatus(safety)
+                .build();
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiSummarizeClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiSummarizeClient.java
@@ -6,6 +6,7 @@ import com.wilo.server.chatbot.client.dto.AiSummarizeResponse;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
 import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -33,16 +34,18 @@ public class RealAiSummarizeClient implements AiSummarizeClient {
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(req)
                 .retrieve()
-                .onStatus(
-                        s -> s.value() == 502 || s.value() == 503 || s.value() == 504,
-                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED))
-                )
+                .onStatus(HttpStatusCode::is5xxServerError,
+                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED)))
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID)))
                 .bodyToMono(AiSummarizeResponse.class)
                 .timeout(Duration.ofSeconds(60))
                 .retryWhen(
                         Retry.max(1).filter(ex -> ex instanceof java.util.concurrent.TimeoutException
                                         || ex instanceof ApplicationException).transientErrors(true)
                 )
+                .onErrorMap(java.util.concurrent.TimeoutException.class,
+                        ex -> new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED))
                 .block();
 
         if (res == null) {

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiSummarizeClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiSummarizeClient.java
@@ -1,0 +1,57 @@
+package com.wilo.server.chatbot.client;
+
+import com.wilo.server.chatbot.client.dto.AiRoleMessage;
+import com.wilo.server.chatbot.client.dto.AiSummarizeRequest;
+import com.wilo.server.chatbot.client.dto.AiSummarizeResponse;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RealAiSummarizeClient implements AiSummarizeClient {
+
+    private final WebClient aiWebClient;
+
+    @Override
+    public AiSummarizeResult summarize(List<AiRoleMessage> messages) {
+
+        AiSummarizeRequest req = AiSummarizeRequest.builder()
+                .messages(messages == null ? List.of() : messages)
+                .build();
+
+        AiSummarizeResponse res = aiWebClient.post()
+                .uri("/summarize")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(req)
+                .retrieve()
+                .onStatus(
+                        s -> s.value() == 502 || s.value() == 503 || s.value() == 504,
+                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED))
+                )
+                .bodyToMono(AiSummarizeResponse.class)
+                .timeout(Duration.ofSeconds(60))
+                .retryWhen(
+                        Retry.max(1).filter(ex -> ex instanceof java.util.concurrent.TimeoutException
+                                        || ex instanceof ApplicationException).transientErrors(true)
+                )
+                .block();
+
+        if (res == null) {
+            throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
+        }
+
+        return AiSummarizeResult.builder()
+                .summary(res.getSummary() == null ? "" : res.getSummary())
+                .keyTopics(res.getKey_topics() == null ? List.of() : res.getKey_topics())
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/client/dto/AiChatRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/client/dto/AiChatRequest.java
@@ -1,5 +1,6 @@
 package com.wilo.server.chatbot.client.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.util.List;
@@ -10,10 +11,18 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor @Builder
 public class AiChatRequest {
-    private String request_id;
-    private String user_id;
-    private String session_id;
-    private String persona_id;
+    @JsonProperty("request_id")
+    private String requestId;
+
+    @JsonProperty("user_id")
+    private String userId;
+
+    @JsonProperty("session_id")
+    private String sessionId;
+
+    @JsonProperty("persona_id")
+    private String personaId;
+
     private String message;
     private Context context;
     private String persona; // legacy (optional)
@@ -24,8 +33,10 @@ public class AiChatRequest {
     @AllArgsConstructor
     @Builder
     public static class Context {
-        private List<AiRoleMessage> recent_messages;
-        private String session_summary;
+        @JsonProperty("recent_messages")
+        private List<AiRoleMessage> recentMessages;
+        @JsonProperty("session_summary")
+        private String sessionSummary;
         private Map<String, Object> memory;
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/client/dto/AiChatRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/client/dto/AiChatRequest.java
@@ -1,0 +1,31 @@
+package com.wilo.server.chatbot.client.dto;
+
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor @Builder
+public class AiChatRequest {
+    private String request_id;
+    private String user_id;
+    private String session_id;
+    private String persona_id;
+    private String message;
+    private Context context;
+    private String persona; // legacy (optional)
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Context {
+        private List<AiRoleMessage> recent_messages;
+        private String session_summary;
+        private Map<String, Object> memory;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/client/dto/AiChatResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/client/dto/AiChatResponse.java
@@ -1,5 +1,6 @@
 package com.wilo.server.chatbot.client.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.util.List;
@@ -11,15 +12,19 @@ import java.util.Map;
 @AllArgsConstructor
 @Builder
 public class AiChatResponse {
-    private String request_id;
+    @JsonProperty("request_id")
+    private String requestId;
     private String persona;
     private String answer;
     private List<String> choices;
-    private String safety_status;   // "clear" | "monitor" | "caution" | "crisis"
+    @JsonProperty("safety_status")
+    private String safetyStatus;   // "clear" | "monitor" | "caution" | "crisis"
     private List<Citation> citations; // 항상 배열
     private String status;
-    private String error_type;
-    private Map<String, Object> memory_patch; // null 가능
+    @JsonProperty("error_type")
+    private String errorType;
+    @JsonProperty("memory_patch")
+    private Map<String, Object> memoryPatch; // null 가능
 
     @Getter
     @Setter
@@ -27,8 +32,10 @@ public class AiChatResponse {
     @AllArgsConstructor
     @Builder
     public static class Citation {
-        private String doc_id;
-        private String chunk_id;
+        @JsonProperty("doc_id")
+        private String docId;
+        @JsonProperty("chunk_id")
+        private String chunkId;
         private String title;
         private String source;
         private Double similarity;

--- a/src/main/java/com/wilo/server/chatbot/client/dto/AiChatResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/client/dto/AiChatResponse.java
@@ -1,0 +1,37 @@
+package com.wilo.server.chatbot.client.dto;
+
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiChatResponse {
+    private String request_id;
+    private String persona;
+    private String answer;
+    private List<String> choices;
+    private String safety_status;   // "clear" | "monitor" | "caution" | "crisis"
+    private List<Citation> citations; // 항상 배열
+    private String status;
+    private String error_type;
+    private Map<String, Object> memory_patch; // null 가능
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Citation {
+        private String doc_id;
+        private String chunk_id;
+        private String title;
+        private String source;
+        private Double similarity;
+        private String snippet;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/client/dto/AiRoleMessage.java
+++ b/src/main/java/com/wilo/server/chatbot/client/dto/AiRoleMessage.java
@@ -1,0 +1,15 @@
+package com.wilo.server.chatbot.client.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiRoleMessage {
+    private String role;
+
+    // 실제 메시지 내용
+    private String content;
+}

--- a/src/main/java/com/wilo/server/chatbot/client/dto/AiSummarizeRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/client/dto/AiSummarizeRequest.java
@@ -1,0 +1,14 @@
+package com.wilo.server.chatbot.client.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiSummarizeRequest {
+    private List<AiRoleMessage> messages;
+}

--- a/src/main/java/com/wilo/server/chatbot/client/dto/AiSummarizeResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/client/dto/AiSummarizeResponse.java
@@ -1,0 +1,15 @@
+package com.wilo.server.chatbot.client.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiSummarizeResponse {
+    private String summary;
+    private List<String> key_topics;
+}

--- a/src/main/java/com/wilo/server/chatbot/config/ChatbotTypeSeeder.java
+++ b/src/main/java/com/wilo/server/chatbot/config/ChatbotTypeSeeder.java
@@ -5,6 +5,7 @@ import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,14 +35,16 @@ public class ChatbotTypeSeeder implements ApplicationRunner {
             return;
         }
 
-        chatbotTypeRepository.save(
-                ChatbotType.create(
-                        code,
-                        name,
-                        desc,
-                        imageUrl,
-                        true
-                )
-        );
+        try {
+            chatbotTypeRepository.save(
+                    ChatbotType.create(
+                            code,
+                            name,
+                            desc,
+                            imageUrl,
+                            true)
+            );
+        } catch (DataIntegrityViolationException ignored) {
+        }
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/config/ChatbotTypeSeeder.java
+++ b/src/main/java/com/wilo/server/chatbot/config/ChatbotTypeSeeder.java
@@ -1,0 +1,47 @@
+package com.wilo.server.chatbot.config;
+
+import com.wilo.server.chatbot.entity.ChatbotType;
+import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ChatbotTypeSeeder implements ApplicationRunner {
+
+    private final ChatbotTypeRepository chatbotTypeRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+
+        seed("EUNHAENG", "편안한 친구", "지금의 상태를 먼저 읽어주는 존재",
+                "https://cdn.wilo.com/chatbot/eunhaeng.png");
+
+        seed("BUDDLE", "따뜻한 조력자", "선택을 대신하지 않고 정리해주는 존재",
+                "https://cdn.wilo.com/chatbot/buddle.png");
+
+        seed("NEUTY", "안전한 동반자", "혼자가 되지 않도록 곁을 지키는 존재",
+                "https://cdn.wilo.com/chatbot/neuty.png");
+    }
+
+    private void seed(String code, String name, String desc, String imageUrl) {
+
+        if (chatbotTypeRepository.existsByCode(code)) {
+            return;
+        }
+
+        chatbotTypeRepository.save(
+                ChatbotType.create(
+                        code,
+                        name,
+                        desc,
+                        imageUrl,
+                        true
+                )
+        );
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSessionMemory.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSessionMemory.java
@@ -1,0 +1,44 @@
+package com.wilo.server.chatbot.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "chat_session_memory")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatSessionMemory {
+    @Id
+    @Column(name = "session_id")
+    private Long sessionId;
+
+    @Lob
+    @Column(nullable = false)
+    private String summary;
+
+    @Lob
+    @Column(name = "key_topics_json", nullable = false)
+    private String keyTopicsJson;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static ChatSessionMemory upsert(Long sessionId, String summary, String keyTopicsJson) {
+        ChatSessionMemory m = new ChatSessionMemory();
+        m.sessionId = sessionId;
+        m.summary = (summary == null) ? "" : summary;
+        m.keyTopicsJson = (keyTopicsJson == null) ? "[]" : keyTopicsJson;
+        m.updatedAt = LocalDateTime.now();
+        return m;
+    }
+
+    public void update(String summary, String keyTopicsJson) {
+        this.summary = (summary == null) ? "" : summary;
+        this.keyTopicsJson = (keyTopicsJson == null) ? "[]" : keyTopicsJson;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatbotPersona.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatbotPersona.java
@@ -8,7 +8,7 @@ public enum ChatbotPersona {
     public static ChatbotPersona from(String code) {
         try {
             return ChatbotPersona.valueOf(code);
-        } catch (Exception e) {
+        } catch (IllegalArgumentException | NullPointerException e) {
             throw new IllegalArgumentException("Invalid persona: " + code);
         }
     }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatbotPersona.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatbotPersona.java
@@ -1,0 +1,15 @@
+package com.wilo.server.chatbot.entity;
+
+public enum ChatbotPersona {
+    EUNHAENG,
+    BUDDLE,
+    NEUTY;
+
+    public static ChatbotPersona from(String code) {
+        try {
+            return ChatbotPersona.valueOf(code);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid persona: " + code);
+        }
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatbotType.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatbotType.java
@@ -29,4 +29,20 @@ public class ChatbotType {
 
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
+
+    public static ChatbotType create(
+            String code,
+            String name,
+            String description,
+            String imageUrl,
+            boolean isActive
+    ) {
+        ChatbotType t = new ChatbotType();
+        t.code = code;
+        t.name = name;
+        t.description = description;
+        t.imageUrl = imageUrl;
+        t.isActive = isActive;
+        return t;
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -3,6 +3,7 @@ package com.wilo.server.chatbot.repository;
 import com.wilo.server.chatbot.entity.ChatMessage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +23,28 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             @Param("cursor") Long cursor,
             Pageable pageable
     );
+
+    @Query("""
+        select m
+        from ChatMessage m
+        where m.sessionId = :sessionId
+        order by m.id desc
+    """)
+    List<ChatMessage> findRecentDesc(Long sessionId, Pageable pageable);
+
+    @Query("""
+        select m
+        from ChatMessage m
+        where m.sessionId = :sessionId
+        order by m.id asc
+    """)
+    List<ChatMessage> findOldestAsc(Long sessionId, Pageable pageable);
+
+    @Modifying
+    @Query("""
+        delete from ChatMessage m
+        where m.sessionId = :sessionId
+          and m.id < :keepFromId
+    """)
+    int deleteOlderThan(Long sessionId, Long keepFromId);
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -30,7 +30,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         where m.sessionId = :sessionId
         order by m.id desc
     """)
-    List<ChatMessage> findRecentDesc(Long sessionId, Pageable pageable);
+    List<ChatMessage> findRecentDesc(@Param("sessionId") Long sessionId, Pageable pageable);
 
     @Query("""
         select m
@@ -38,13 +38,13 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         where m.sessionId = :sessionId
         order by m.id asc
     """)
-    List<ChatMessage> findOldestAsc(Long sessionId, Pageable pageable);
+    List<ChatMessage> findOldestAsc(@Param("sessionId") Long sessionId, Pageable pageable);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
         delete from ChatMessage m
         where m.sessionId = :sessionId
           and m.id < :keepFromId
     """)
-    int deleteOlderThan(Long sessionId, Long keepFromId);
+    int deleteOlderThan(@Param("sessionId") Long sessionId, @Param("keepFromId") Long keepFromId);
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionMemoryRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionMemoryRepository.java
@@ -1,0 +1,7 @@
+package com.wilo.server.chatbot.repository;
+
+import com.wilo.server.chatbot.entity.ChatSessionMemory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatSessionMemoryRepository extends JpaRepository<ChatSessionMemory, Long> {
+}

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatbotTypeRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatbotTypeRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ChatbotTypeRepository extends JpaRepository<ChatbotType, Long> {
 
     List<ChatbotType> findAllByIsActiveTrueOrderByIdAsc();
+    boolean existsByCode(String code);
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
@@ -21,11 +21,7 @@ public class ChatMessageService {
     private final AiChatClient aiChatClient;
     private final ChatMessageTxService chatMessageTxService;
 
-    public ChatMessageSendResponse sendMessage(
-            Long sessionId,
-            String guestIdHeader,
-            ChatMessageSendRequest request
-    ) {
+    public ChatMessageSendResponse sendMessage(Long sessionId, String guestIdHeader, ChatMessageSendRequest request) {
 
         Long userId = extractUserIdIfAuthenticated();
         String guestId = normalizeGuestId(guestIdHeader);
@@ -34,21 +30,29 @@ public class ChatMessageService {
             throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
         }
 
-        // 세션 권한 체크 + personaId 얻기
-        Long personaId = chatMessageTxService.getPersonaIdWithAuthCheck(sessionId, userId, guestId);
+        // personaCode 얻기
+        String personaCode = chatMessageTxService.getPersonaCodeWithAuthCheck(sessionId, userId, guestId);
 
-        // USER 메시지 저장
+        // USER 저장
         ChatMessage savedUser = chatMessageTxService.saveUserMessage(sessionId, request);
 
-        // AI 호출
+        // context 구성 (최근 N턴 + summary)
+        String summary = chatMessageTxService.getSessionSummary(sessionId);
+        var recent = chatMessageTxService.findRecentAiMessages(sessionId, 20); // 정책값
+
         String requester = (userId != null) ? String.valueOf(userId) : guestId;
+        String requestId = java.util.UUID.randomUUID().toString();
 
         AiChatResult aiResult = aiChatClient.chat(
                 AiChatCommand.builder()
+                        .requestId(requestId)
                         .userId(requester)
                         .sessionId(sessionId)
-                        .personaId(personaId)
+                        .personaId(personaCode)
                         .message(request.getMessage())
+                        .sessionSummary(summary)
+                        .recentMessages(recent)
+                        .memory(null) // 1차는 null로
                         .build()
         );
 
@@ -56,7 +60,6 @@ public class ChatMessageService {
             throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
         }
 
-        // BOT 메시지 저장 + lastMessageAt 업데이트
         ChatMessage savedBot = chatMessageTxService.saveBotMessageWithSessionUpdate(sessionId, aiResult);
 
         return ChatMessageSendResponse.builder()

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -111,17 +111,24 @@ public class ChatMessageTxService {
     }
 
     @Transactional(readOnly = true)
-    public String getPersonaCodeWithAuthCheck(Long sessionId, Long userId, String guestId) {
+    public String getPersonaCodeWithAuthCheck(
+            Long sessionId,
+            Long userId,
+            String guestId
+    ) {
         ChatSession session = chatSessionRepository
                 .findByIdWithChatbotType(sessionId)
                 .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
 
         boolean isOwner = (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
-                || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
 
-        if (!isOwner) throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        if (!isOwner) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+        }
+        String code = session.getChatbotType().getCode();
 
-        return session.getChatbotType().getCode();
+        return ChatbotPersona.from(code).name();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -6,10 +6,7 @@ import com.wilo.server.chatbot.client.AiChatResult;
 import com.wilo.server.chatbot.client.dto.AiRoleMessage;
 import com.wilo.server.chatbot.dto.ChatMessageDto;
 import com.wilo.server.chatbot.dto.ChatMessageSendRequest;
-import com.wilo.server.chatbot.entity.ChatMessage;
-import com.wilo.server.chatbot.entity.ChatSession;
-import com.wilo.server.chatbot.entity.ChatSessionMemory;
-import com.wilo.server.chatbot.entity.MessageType;
+import com.wilo.server.chatbot.entity.*;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
 import com.wilo.server.chatbot.repository.ChatMessageRepository;
 import com.wilo.server.chatbot.repository.ChatSessionMemoryRepository;
@@ -135,7 +132,7 @@ public class ChatMessageTxService {
 
         return recentDesc.stream()
                 .map(m -> AiRoleMessage.builder()
-                        .role(m.getSenderType().name().equals("USER") ? "user" : "assistant")
+                        .role(m.getSenderType() == SenderType.USER ? "user" : "assistant")
                         .content(m.getContent())
                         .build())
                 .toList();

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -3,20 +3,25 @@ package com.wilo.server.chatbot.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wilo.server.chatbot.client.AiChatResult;
+import com.wilo.server.chatbot.client.dto.AiRoleMessage;
 import com.wilo.server.chatbot.dto.ChatMessageDto;
 import com.wilo.server.chatbot.dto.ChatMessageSendRequest;
 import com.wilo.server.chatbot.entity.ChatMessage;
 import com.wilo.server.chatbot.entity.ChatSession;
+import com.wilo.server.chatbot.entity.ChatSessionMemory;
 import com.wilo.server.chatbot.entity.MessageType;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
 import com.wilo.server.chatbot.repository.ChatMessageRepository;
+import com.wilo.server.chatbot.repository.ChatSessionMemoryRepository;
 import com.wilo.server.chatbot.repository.ChatSessionRepository;
 import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 @Slf4j
@@ -26,6 +31,7 @@ public class ChatMessageTxService {
 
     private final ChatSessionRepository chatSessionRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatSessionMemoryRepository chatSessionMemoryRepository;
     private final ObjectMapper objectMapper;
 
     @Transactional(readOnly = true)
@@ -105,5 +111,40 @@ public class ChatMessageTxService {
                 .choices(choices)
                 .attachments(List.of())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public String getPersonaCodeWithAuthCheck(Long sessionId, Long userId, String guestId) {
+        ChatSession session = chatSessionRepository
+                .findByIdWithChatbotType(sessionId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        boolean isOwner = (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
+                || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+
+        if (!isOwner) throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
+
+        return session.getChatbotType().getCode();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AiRoleMessage> findRecentAiMessages(Long sessionId, int n) {
+        List<ChatMessage> recentDesc = chatMessageRepository.findRecentDesc(sessionId, PageRequest.of(0, n));
+        // desc → asc로 바꿔 대화 순서 유지
+        Collections.reverse(recentDesc);
+
+        return recentDesc.stream()
+                .map(m -> AiRoleMessage.builder()
+                        .role(m.getSenderType().name().equals("USER") ? "user" : "assistant")
+                        .content(m.getContent())
+                        .build())
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public String getSessionSummary(Long sessionId) {
+        return chatSessionMemoryRepository.findById(sessionId)
+                .map(ChatSessionMemory::getSummary)
+                .orElse("");
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -133,6 +133,9 @@ public class ChatMessageTxService {
 
     @Transactional(readOnly = true)
     public List<AiRoleMessage> findRecentAiMessages(Long sessionId, int n) {
+        if (n <= 0) {
+            return List.of();
+        }
         List<ChatMessage> recentDesc = chatMessageRepository.findRecentDesc(sessionId, PageRequest.of(0, n));
         // desc → asc로 바꿔 대화 순서 유지
         return recentDesc.reversed().stream()

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -135,9 +135,7 @@ public class ChatMessageTxService {
     public List<AiRoleMessage> findRecentAiMessages(Long sessionId, int n) {
         List<ChatMessage> recentDesc = chatMessageRepository.findRecentDesc(sessionId, PageRequest.of(0, n));
         // desc → asc로 바꿔 대화 순서 유지
-        Collections.reverse(recentDesc);
-
-        return recentDesc.stream()
+        return recentDesc.reversed().stream()
                 .map(m -> AiRoleMessage.builder()
                         .role(m.getSenderType() == SenderType.USER ? "user" : "assistant")
                         .content(m.getContent())

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSummaryService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSummaryService.java
@@ -1,0 +1,104 @@
+package com.wilo.server.chatbot.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wilo.server.chatbot.client.AiSummarizeClient;
+import com.wilo.server.chatbot.client.AiSummarizeResult;
+import com.wilo.server.chatbot.client.dto.AiRoleMessage;
+import com.wilo.server.chatbot.entity.ChatMessage;
+import com.wilo.server.chatbot.entity.ChatSessionMemory;
+import com.wilo.server.chatbot.repository.ChatMessageRepository;
+import com.wilo.server.chatbot.repository.ChatSessionMemoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatSummaryService {
+
+    private static final int KEEP_RECENT_N = 30;     // 최근 N턴 유지
+    private static final int SUMMARIZE_BATCH = 1000; // 요약할 최대 raw 수
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatSessionMemoryRepository chatSessionMemoryRepository;
+    private final AiSummarizeClient aiSummarizeClient;
+    private final ObjectMapper objectMapper;
+
+    // 세션 만료 시 호출
+    @Transactional
+    public void summarizeAndPrune(Long sessionId) {
+
+        // 최신 KEEP_RECENT_N개를 남기기 위해, 최신 N개 중 가장 작은 id를 keepFromId로 사용
+        List<ChatMessage> recentDesc = chatMessageRepository.findRecentDesc(
+                sessionId,
+                PageRequest.of(0, KEEP_RECENT_N)
+        );
+
+        if (recentDesc.isEmpty()) {
+            return;
+        }
+
+        Long keepFromId = recentDesc.stream()
+                .map(ChatMessage::getId)
+                .min(Long::compareTo)
+                .orElse(null);
+
+        // keepFromId 이전의 오래된 메시지들을 요약 대상으로 수집 (DB에 오래된 메시지가 많이 쌓이지 않도록 상한 설정)
+        List<ChatMessage> oldestAsc = chatMessageRepository.findOldestAsc(sessionId, PageRequest.of(0, SUMMARIZE_BATCH));
+
+        // 전체가 KEEP_RECENT_N 이하라면 prune/요약 스킵
+        if (oldestAsc.size() <= KEEP_RECENT_N) {
+            return;
+        }
+
+        // 요약 대상 = keepFromId 미만
+        List<ChatMessage> toSummarize = oldestAsc.stream()
+                .filter(m -> m.getId() < keepFromId)
+                .toList();
+
+        if (toSummarize.isEmpty()) {
+            return;
+        }
+
+        // role+content만 전달
+        List<AiRoleMessage> aiMsgs = toSummarize.stream()
+                .map(m -> AiRoleMessage.builder()
+                        .role(m.getSenderType().name().equals("USER") ? "user" : "assistant")
+                        .content(m.getContent()) // TODO: PII sanitizer 적용
+                        .build())
+                .toList();
+
+        AiSummarizeResult result = aiSummarizeClient.summarize(aiMsgs);
+
+        // 빈 입력이면 summary="" 내려올 수 있음. 빈 요약이면 저장 스킵
+        if (result.getSummary() == null || result.getSummary().isBlank()) {
+            log.info("summarize empty sessionId={}", sessionId);
+            return;
+        }
+
+        String keyTopicsJson;
+        try {
+            keyTopicsJson = objectMapper.writeValueAsString(result.getKeyTopics());
+        } catch (Exception e) {
+            keyTopicsJson = "[]";
+        }
+
+        ChatSessionMemory mem = chatSessionMemoryRepository.findById(sessionId).orElse(null);
+        if (mem == null) {
+            chatSessionMemoryRepository.save(
+                    ChatSessionMemory.upsert(sessionId, result.getSummary(), keyTopicsJson)
+            );
+        } else {
+            mem.update(result.getSummary(), keyTopicsJson);
+        }
+
+        // 오래된 raw 삭제
+        int deleted = chatMessageRepository.deleteOlderThan(sessionId, keepFromId);
+        log.info("prune sessionId={} keepFromId={} deleted={}", sessionId, keepFromId, deleted);
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSummaryService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSummaryService.java
@@ -6,6 +6,7 @@ import com.wilo.server.chatbot.client.AiSummarizeResult;
 import com.wilo.server.chatbot.client.dto.AiRoleMessage;
 import com.wilo.server.chatbot.entity.ChatMessage;
 import com.wilo.server.chatbot.entity.ChatSessionMemory;
+import com.wilo.server.chatbot.entity.SenderType;
 import com.wilo.server.chatbot.repository.ChatMessageRepository;
 import com.wilo.server.chatbot.repository.ChatSessionMemoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -68,7 +69,7 @@ public class ChatSummaryService {
         // role+content만 전달
         List<AiRoleMessage> aiMsgs = toSummarize.stream()
                 .map(m -> AiRoleMessage.builder()
-                        .role(m.getSenderType().name().equals("USER") ? "user" : "assistant")
+                        .role(m.getSenderType() == SenderType.USER ? "user" : "assistant")
                         .content(m.getContent()) // TODO: PII sanitizer 적용
                         .build())
                 .toList();
@@ -85,6 +86,7 @@ public class ChatSummaryService {
         try {
             keyTopicsJson = objectMapper.writeValueAsString(result.getKeyTopics());
         } catch (Exception e) {
+            log.warn("keyTopics 직렬화 실패 sessionId={}", sessionId, e);
             keyTopicsJson = "[]";
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #28 

## 📝 작업 내용

**1. 메시지 전송 API 구현**
사용자가 입력한 메시지를 저장한 뒤 AI 서버 /chat API를 호출하여 응답을 생성하고, USER/BOT 메시지를 함께 반환하는 API를 구현했습니다.

```
처리 흐름
로그인 사용자 → JWT userId 기반 인증
비로그인 사용자 → X-Guest-Id 기반 인증
세션 소유자 검증
사용자 메시지 저장
최근 N턴 메시지 조회
세션 summary 조회
AI 서버 /chat 호출
AI 응답 파싱
BOT 메시지 저장
USER/BOT 메시지 함께 반환
```

**2. AI 서버 연동 구현**
AI 서버 /chat API와 연동하기 위한 Client 구조를 구현했습니다.

**3. AI Context 전달 구조 구현**
AI 요청 시 context 정보를 포함하도록 구현했습니다.

**4. Persona 코드 기반 AI 연동 구조 구현**
ChatSession → ChatbotType → code 구조를 사용하여 persona_id를 AI 서버와 동일하게 전달하도록 구현했습니다.


**5. AI 응답 파싱 및 저장 구현**
AI 응답을 파싱하여 BOT 메시지로 저장하도록 구현했습니다.

## 🖼️ 스크린샷 (선택)
###  AI 서버와의 연동을 통한 메시지 전송 성공
<img width="1468" height="943" alt="메시지전송ai연동성공" src="https://github.com/user-attachments/assets/e33cbc5b-d46a-4f36-92f1-2fa06ecde25c" />



## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AI 챗에 세션 컨텍스트(세션 요약, 최근 메시지, 메모리) 반영
  * 채팅 기록 자동 요약 및 오래된 메시지 정리 배치 추가
  * AI 응답 안전성 매핑/모니터링 추가
  * 다중 챗봇 페르소나 지원 및 초기 페르소나 시드

* **개선사항**
  * 메시지 조회·삭제 및 관리 기능 강화
  * AI 요청 추적성 개선(고유 요청 ID) 및 응답 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->