### PR TITLE
[FEAT] 알림 기능 API 구현 완료

### DIFF
--- a/src/main/java/com/wilo/server/community/service/CommunityService.java
+++ b/src/main/java/com/wilo/server/community/service/CommunityService.java
@@ -21,6 +21,7 @@ import com.wilo.server.community.repository.CommunityPostImageRepository;
 import com.wilo.server.community.repository.CommunityPostLikeRepository;
 import com.wilo.server.community.repository.CommunityPostRepository;
 import com.wilo.server.global.exception.ApplicationException;
+import com.wilo.server.notification.service.NotificationService;
 import com.wilo.server.user.entity.User;
 import com.wilo.server.user.error.UserErrorCase;
 import com.wilo.server.user.repository.UserRepository;
@@ -49,6 +50,7 @@ public class CommunityService {
     private final CommunityCommentRepository communityCommentRepository;
     private final CommunityPostLikeRepository communityPostLikeRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public Long createPost(Long userId, CommunityPostCreateRequestDto request) {
@@ -230,6 +232,7 @@ public class CommunityService {
         );
 
         post.increaseCommentCount();
+        notificationService.notifyComment(post, user, comment);
 
         return CommunityCommentDto.of(
                 comment.getId(),
@@ -254,6 +257,7 @@ public class CommunityService {
                             .build()
             );
             post.increaseLikeCount();
+            notificationService.notifyPostLike(post, user);
         }
 
         return new CommunityLikeResponseDto(true, post.getLikeCount());

--- a/src/main/java/com/wilo/server/notification/controller/NotificationController.java
+++ b/src/main/java/com/wilo/server/notification/controller/NotificationController.java
@@ -142,6 +142,24 @@ public class NotificationController {
         return CommonResponse.success("알림이 삭제되었습니다.");
     }
 
+    @DeleteMapping
+    @Operation(summary = "알림 전체 삭제", description = "내 알림 전체를 삭제하고 삭제 건수를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전체 삭제 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":1005,\"message\":\"로그인이 필요합니다.\"}")
+                    )
+            )
+    })
+    public CommonResponse<Integer> deleteAllUserNotifications() {
+        Long userId = extractUserId();
+        return CommonResponse.success(notificationService.deleteAllUserNotifications(userId));
+    }
+
     private Long extractUserId() {
         Object principal = SecurityContextHolder.getContext().getAuthentication() != null
                 ? SecurityContextHolder.getContext().getAuthentication().getPrincipal()

--- a/src/main/java/com/wilo/server/notification/controller/NotificationController.java
+++ b/src/main/java/com/wilo/server/notification/controller/NotificationController.java
@@ -5,6 +5,14 @@ import com.wilo.server.global.exception.ApplicationException;
 import com.wilo.server.global.response.CommonResponse;
 import com.wilo.server.notification.dto.NotificationListResponseDto;
 import com.wilo.server.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,13 +25,28 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notifications")
+@Tag(name = "Notification", description = "유저 알림 API")
 public class NotificationController {
 
     private final NotificationService notificationService;
 
     @GetMapping
+    @Operation(summary = "알림 목록 조회", description = "내 알림을 최신순(createdAt desc, id desc)으로 조회하며 커서 기반 무한 스크롤을 지원합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":1005,\"message\":\"로그인이 필요합니다.\"}")
+                    )
+            )
+    })
     public CommonResponse<NotificationListResponseDto> getNotifications(
+            @Parameter(description = "커서 값. 포맷: createdAt|id")
             @RequestParam(required = false) String cursor,
+            @Parameter(description = "페이지 크기. 기본값 20, 최대 50")
             @RequestParam(defaultValue = "20") Integer size
     ) {
         Long userId = extractUserId();
@@ -31,6 +54,34 @@ public class NotificationController {
     }
 
     @PatchMapping("/{notificationId}/read")
+    @Operation(summary = "알림 단건 읽음 처리", description = "내 알림 1건을 읽음 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "읽음 처리 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":1005,\"message\":\"로그인이 필요합니다.\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "타인 알림 접근",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":7002,\"message\":\"본인의 알림만 처리할 수 있습니다.\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "알림 없음",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":7001,\"message\":\"알림을 찾을 수 없습니다.\"}")
+                    )
+            )
+    })
     public CommonResponse<String> markAsRead(@PathVariable Long notificationId) {
         Long userId = extractUserId();
         notificationService.markAsRead(userId, notificationId);
@@ -38,6 +89,18 @@ public class NotificationController {
     }
 
     @PatchMapping("/read-all")
+    @Operation(summary = "알림 전체 읽음 처리", description = "내 미읽음 알림 전체를 읽음 처리하고 처리 건수를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전체 읽음 처리 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":1005,\"message\":\"로그인이 필요합니다.\"}")
+                    )
+            )
+    })
     public CommonResponse<Integer> markAllAsRead() {
         Long userId = extractUserId();
         return CommonResponse.success(notificationService.markAllAsRead(userId));

--- a/src/main/java/com/wilo/server/notification/controller/NotificationController.java
+++ b/src/main/java/com/wilo/server/notification/controller/NotificationController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -104,6 +105,41 @@ public class NotificationController {
     public CommonResponse<Integer> markAllAsRead() {
         Long userId = extractUserId();
         return CommonResponse.success(notificationService.markAllAsRead(userId));
+    }
+
+    @DeleteMapping("/{notificationId}")
+    @Operation(summary = "알림 단건 삭제", description = "내 알림 1건을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":1005,\"message\":\"로그인이 필요합니다.\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "타인 알림 삭제 시도",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":7002,\"message\":\"본인의 알림만 처리할 수 있습니다.\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "알림 없음",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":7001,\"message\":\"알림을 찾을 수 없습니다.\"}")
+                    )
+            )
+    })
+    public CommonResponse<String> deleteNotification(@PathVariable Long notificationId) {
+        Long userId = extractUserId();
+        notificationService.deleteNotification(userId, notificationId);
+        return CommonResponse.success("알림이 삭제되었습니다.");
     }
 
     private Long extractUserId() {

--- a/src/main/java/com/wilo/server/notification/controller/NotificationController.java
+++ b/src/main/java/com/wilo/server/notification/controller/NotificationController.java
@@ -1,0 +1,64 @@
+package com.wilo.server.notification.controller;
+
+import com.wilo.server.auth.error.AuthErrorCase;
+import com.wilo.server.global.exception.ApplicationException;
+import com.wilo.server.global.response.CommonResponse;
+import com.wilo.server.notification.dto.NotificationListResponseDto;
+import com.wilo.server.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public CommonResponse<NotificationListResponseDto> getNotifications(
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        Long userId = extractUserId();
+        return CommonResponse.success(notificationService.getNotifications(userId, cursor, size));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public CommonResponse<String> markAsRead(@PathVariable Long notificationId) {
+        Long userId = extractUserId();
+        notificationService.markAsRead(userId, notificationId);
+        return CommonResponse.success("알림이 읽음 처리되었습니다.");
+    }
+
+    @PatchMapping("/read-all")
+    public CommonResponse<Integer> markAllAsRead() {
+        Long userId = extractUserId();
+        return CommonResponse.success(notificationService.markAllAsRead(userId));
+    }
+
+    private Long extractUserId() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication() != null
+                ? SecurityContextHolder.getContext().getAuthentication().getPrincipal()
+                : null;
+
+        if (principal instanceof Long userId) {
+            return userId;
+        }
+
+        if (principal instanceof String userIdText) {
+            try {
+                return Long.parseLong(userIdText);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        throw ApplicationException.from(AuthErrorCase.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/wilo/server/notification/dto/NotificationListResponseDto.java
+++ b/src/main/java/com/wilo/server/notification/dto/NotificationListResponseDto.java
@@ -1,0 +1,12 @@
+package com.wilo.server.notification.dto;
+
+import java.util.List;
+
+public record NotificationListResponseDto(
+        List<NotificationSummaryDto> items,
+        String cursor,
+        int size,
+        boolean hasNext,
+        String nextCursor
+) {
+}

--- a/src/main/java/com/wilo/server/notification/dto/NotificationSummaryDto.java
+++ b/src/main/java/com/wilo/server/notification/dto/NotificationSummaryDto.java
@@ -12,6 +12,7 @@ public record NotificationSummaryDto(
         String commentPreview,
         String actorNickname,
         boolean isRead,
+        String timeAgo,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/wilo/server/notification/dto/NotificationSummaryDto.java
+++ b/src/main/java/com/wilo/server/notification/dto/NotificationSummaryDto.java
@@ -1,0 +1,17 @@
+package com.wilo.server.notification.dto;
+
+import com.wilo.server.notification.entity.NotificationType;
+import java.time.LocalDateTime;
+
+public record NotificationSummaryDto(
+        Long id,
+        NotificationType type,
+        String message,
+        Long postId,
+        Long commentId,
+        String commentPreview,
+        String actorNickname,
+        boolean isRead,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/wilo/server/notification/entity/NotificationType.java
+++ b/src/main/java/com/wilo/server/notification/entity/NotificationType.java
@@ -1,0 +1,6 @@
+package com.wilo.server.notification.entity;
+
+public enum NotificationType {
+    COMMENT,
+    POST_LIKE
+}

--- a/src/main/java/com/wilo/server/notification/entity/UserNotification.java
+++ b/src/main/java/com/wilo/server/notification/entity/UserNotification.java
@@ -1,0 +1,91 @@
+package com.wilo.server.notification.entity;
+
+import com.wilo.server.global.entity.BaseEntity;
+import com.wilo.server.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "user_notifications",
+        indexes = {
+                @Index(name = "idx_notification_receiver_created_id", columnList = "receiver_user_id, created_at, id"),
+                @Index(name = "idx_notification_receiver_isread_created_id", columnList = "receiver_user_id, is_read, created_at, id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNotification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_user_id", nullable = false)
+    private User receiverUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_user_id", nullable = false)
+    private User actorUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private Long postId;
+
+    @Column
+    private Long commentId;
+
+    @Column(length = 300)
+    private String commentPreview;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    @Column
+    private LocalDateTime readAt;
+
+    @Builder
+    private UserNotification(
+            User receiverUser,
+            User actorUser,
+            NotificationType type,
+            Long postId,
+            Long commentId,
+            String commentPreview
+    ) {
+        this.receiverUser = receiverUser;
+        this.actorUser = actorUser;
+        this.type = type;
+        this.postId = postId;
+        this.commentId = commentId;
+        this.commentPreview = commentPreview;
+        this.isRead = false;
+    }
+
+    public void markAsRead() {
+        if (this.isRead) {
+            return;
+        }
+        this.isRead = true;
+        this.readAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wilo/server/notification/error/NotificationErrorCase.java
+++ b/src/main/java/com/wilo/server/notification/error/NotificationErrorCase.java
@@ -1,0 +1,17 @@
+package com.wilo.server.notification.error;
+
+import com.wilo.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCase implements ErrorCase {
+
+    NOTIFICATION_NOT_FOUND(404, 7001, "알림을 찾을 수 없습니다."),
+    FORBIDDEN_NOTIFICATION_ACCESS(403, 7002, "본인의 알림만 처리할 수 있습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String message;
+}

--- a/src/main/java/com/wilo/server/notification/repository/UserNotificationRepository.java
+++ b/src/main/java/com/wilo/server/notification/repository/UserNotificationRepository.java
@@ -19,4 +19,11 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
                and n.isRead = false
             """)
     int markAllAsRead(@Param("receiverUserId") Long receiverUserId, @Param("readAt") LocalDateTime readAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from UserNotification n
+             where n.receiverUser.id = :receiverUserId
+            """)
+    int deleteAllByReceiverUserId(@Param("receiverUserId") Long receiverUserId);
 }

--- a/src/main/java/com/wilo/server/notification/repository/UserNotificationRepository.java
+++ b/src/main/java/com/wilo/server/notification/repository/UserNotificationRepository.java
@@ -1,0 +1,22 @@
+package com.wilo.server.notification.repository;
+
+import com.wilo.server.notification.entity.UserNotification;
+import com.wilo.server.notification.repository.query.UserNotificationQueryRepository;
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserNotificationRepository extends JpaRepository<UserNotification, Long>, UserNotificationQueryRepository {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update UserNotification n
+               set n.isRead = true,
+                   n.readAt = :readAt
+             where n.receiverUser.id = :receiverUserId
+               and n.isRead = false
+            """)
+    int markAllAsRead(@Param("receiverUserId") Long receiverUserId, @Param("readAt") LocalDateTime readAt);
+}

--- a/src/main/java/com/wilo/server/notification/repository/query/UserNotificationQueryRepository.java
+++ b/src/main/java/com/wilo/server/notification/repository/query/UserNotificationQueryRepository.java
@@ -1,0 +1,16 @@
+package com.wilo.server.notification.repository.query;
+
+import com.wilo.server.notification.entity.UserNotification;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface UserNotificationQueryRepository {
+
+    List<UserNotification> findLatestByReceiverWithCursor(
+            Long receiverUserId,
+            LocalDateTime cursorCreatedAt,
+            Long cursorId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/wilo/server/notification/repository/query/UserNotificationQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/notification/repository/query/UserNotificationQueryRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.wilo.server.notification.repository.query;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wilo.server.notification.entity.QUserNotification;
+import com.wilo.server.notification.entity.UserNotification;
+import com.wilo.server.user.entity.QUser;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserNotificationQueryRepositoryImpl implements UserNotificationQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QUserNotification notification = QUserNotification.userNotification;
+    private static final QUser actor = new QUser("actor");
+
+    @Override
+    public List<UserNotification> findLatestByReceiverWithCursor(
+            Long receiverUserId,
+            LocalDateTime cursorCreatedAt,
+            Long cursorId,
+            Pageable pageable
+    ) {
+        return queryFactory
+                .selectFrom(notification)
+                .join(notification.actorUser, actor).fetchJoin()
+                .where(
+                        notification.receiverUser.id.eq(receiverUserId),
+                        cursorCondition(cursorCreatedAt, cursorId)
+                )
+                .orderBy(notification.createdAt.desc(), notification.id.desc())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private BooleanExpression cursorCondition(LocalDateTime cursorCreatedAt, Long cursorId) {
+        if (cursorCreatedAt == null || cursorId == null) {
+            return null;
+        }
+
+        return notification.createdAt.lt(cursorCreatedAt)
+                .or(notification.createdAt.eq(cursorCreatedAt).and(notification.id.lt(cursorId)));
+    }
+}

--- a/src/main/java/com/wilo/server/notification/service/NotificationService.java
+++ b/src/main/java/com/wilo/server/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import com.wilo.server.notification.error.NotificationErrorCase;
 import com.wilo.server.notification.repository.UserNotificationRepository;
 import com.wilo.server.global.exception.ApplicationException;
 import com.wilo.server.user.entity.User;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -137,6 +138,7 @@ public class NotificationService {
                 notification.getCommentPreview(),
                 actorNickname,
                 notification.isRead(),
+                calculateTimeAgo(notification.getCreatedAt()),
                 notification.getCreatedAt()
         );
     }
@@ -149,6 +151,25 @@ public class NotificationService {
             return content;
         }
         return content.substring(0, COMMENT_PREVIEW_LENGTH) + "...";
+    }
+
+    private String calculateTimeAgo(LocalDateTime createdAt) {
+        if (createdAt == null) {
+            return "0분 전";
+        }
+
+        long minutes = Math.max(0, Duration.between(createdAt, LocalDateTime.now()).toMinutes());
+        if (minutes < 60) {
+            return Math.max(1, minutes) + "분 전";
+        }
+
+        long hours = minutes / 60;
+        if (hours < 24) {
+            return hours + "시간 전";
+        }
+
+        long days = hours / 24;
+        return days + "일 전";
     }
 
     private record Cursor(LocalDateTime createdAt, Long id) {

--- a/src/main/java/com/wilo/server/notification/service/NotificationService.java
+++ b/src/main/java/com/wilo/server/notification/service/NotificationService.java
@@ -1,0 +1,168 @@
+package com.wilo.server.notification.service;
+
+import com.wilo.server.community.entity.CommunityComment;
+import com.wilo.server.community.entity.CommunityPost;
+import com.wilo.server.notification.dto.NotificationListResponseDto;
+import com.wilo.server.notification.dto.NotificationSummaryDto;
+import com.wilo.server.notification.entity.NotificationType;
+import com.wilo.server.notification.entity.UserNotification;
+import com.wilo.server.notification.error.NotificationErrorCase;
+import com.wilo.server.notification.repository.UserNotificationRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import com.wilo.server.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private static final int MAX_PAGE_SIZE = 50;
+    private static final int COMMENT_PREVIEW_LENGTH = 120;
+
+    private final UserNotificationRepository userNotificationRepository;
+
+    @Transactional
+    public void notifyComment(CommunityPost post, User actorUser, CommunityComment comment) {
+        if (post.getUser().getId().equals(actorUser.getId())) {
+            return;
+        }
+
+        userNotificationRepository.save(
+                UserNotification.builder()
+                        .receiverUser(post.getUser())
+                        .actorUser(actorUser)
+                        .type(NotificationType.COMMENT)
+                        .postId(post.getId())
+                        .commentId(comment.getId())
+                        .commentPreview(createPreview(comment.getContent()))
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void notifyPostLike(CommunityPost post, User actorUser) {
+        if (post.getUser().getId().equals(actorUser.getId())) {
+            return;
+        }
+
+        userNotificationRepository.save(
+                UserNotification.builder()
+                        .receiverUser(post.getUser())
+                        .actorUser(actorUser)
+                        .type(NotificationType.POST_LIKE)
+                        .postId(post.getId())
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationListResponseDto getNotifications(Long receiverUserId, String cursor, Integer size) {
+        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
+        Pageable pageable = PageRequest.of(0, safeSize + 1);
+
+        Cursor parsedCursor = Cursor.from(cursor);
+        List<UserNotification> fetchedNotifications = userNotificationRepository.findLatestByReceiverWithCursor(
+                receiverUserId,
+                parsedCursor.createdAt(),
+                parsedCursor.id(),
+                pageable
+        );
+
+        boolean hasNext = fetchedNotifications.size() > safeSize;
+        List<UserNotification> pageNotifications = hasNext
+                ? fetchedNotifications.subList(0, safeSize)
+                : fetchedNotifications;
+
+        List<NotificationSummaryDto> items = pageNotifications.stream()
+                .map(this::toDto)
+                .toList();
+
+        String nextCursor = null;
+        if (hasNext && !pageNotifications.isEmpty()) {
+            UserNotification last = pageNotifications.get(pageNotifications.size() - 1);
+            nextCursor = Cursor.of(last).toCursorValue();
+        }
+
+        return new NotificationListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
+    }
+
+    @Transactional
+    public void markAsRead(Long receiverUserId, Long notificationId) {
+        UserNotification notification = userNotificationRepository.findById(notificationId)
+                .orElseThrow(() -> ApplicationException.from(NotificationErrorCase.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getReceiverUser().getId().equals(receiverUserId)) {
+            throw ApplicationException.from(NotificationErrorCase.FORBIDDEN_NOTIFICATION_ACCESS);
+        }
+
+        notification.markAsRead();
+    }
+
+    @Transactional
+    public int markAllAsRead(Long receiverUserId) {
+        return userNotificationRepository.markAllAsRead(receiverUserId, LocalDateTime.now());
+    }
+
+    private NotificationSummaryDto toDto(UserNotification notification) {
+        String actorNickname = notification.getActorUser().getNickname();
+        String message = switch (notification.getType()) {
+            case COMMENT -> actorNickname + "님이 회원님의 글에 댓글을 남겼습니다.";
+            case POST_LIKE -> actorNickname + "님이 회원님의 글을 좋아합니다.";
+        };
+
+        return new NotificationSummaryDto(
+                notification.getId(),
+                notification.getType(),
+                message,
+                notification.getPostId(),
+                notification.getCommentId(),
+                notification.getCommentPreview(),
+                actorNickname,
+                notification.isRead(),
+                notification.getCreatedAt()
+        );
+    }
+
+    private String createPreview(String content) {
+        if (content == null) {
+            return "";
+        }
+        if (content.length() <= COMMENT_PREVIEW_LENGTH) {
+            return content;
+        }
+        return content.substring(0, COMMENT_PREVIEW_LENGTH) + "...";
+    }
+
+    private record Cursor(LocalDateTime createdAt, Long id) {
+        private static Cursor from(String cursor) {
+            if (cursor == null || cursor.isBlank()) {
+                return new Cursor(null, null);
+            }
+
+            String[] parts = cursor.split("\\|");
+            if (parts.length != 2) {
+                return new Cursor(null, null);
+            }
+
+            try {
+                return new Cursor(LocalDateTime.parse(parts[0]), Long.parseLong(parts[1]));
+            } catch (RuntimeException e) {
+                return new Cursor(null, null);
+            }
+        }
+
+        private static Cursor of(UserNotification notification) {
+            return new Cursor(notification.getCreatedAt(), notification.getId());
+        }
+
+        private String toCursorValue() {
+            return createdAt + "|" + id;
+        }
+    }
+}

--- a/src/main/java/com/wilo/server/notification/service/NotificationService.java
+++ b/src/main/java/com/wilo/server/notification/service/NotificationService.java
@@ -109,6 +109,18 @@ public class NotificationService {
         return userNotificationRepository.markAllAsRead(receiverUserId, LocalDateTime.now());
     }
 
+    @Transactional
+    public void deleteNotification(Long receiverUserId, Long notificationId) {
+        UserNotification notification = userNotificationRepository.findById(notificationId)
+                .orElseThrow(() -> ApplicationException.from(NotificationErrorCase.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getReceiverUser().getId().equals(receiverUserId)) {
+            throw ApplicationException.from(NotificationErrorCase.FORBIDDEN_NOTIFICATION_ACCESS);
+        }
+
+        userNotificationRepository.delete(notification);
+    }
+
     private NotificationSummaryDto toDto(UserNotification notification) {
         String actorNickname = notification.getActorUser().getNickname();
         String message = switch (notification.getType()) {

--- a/src/main/java/com/wilo/server/notification/service/NotificationService.java
+++ b/src/main/java/com/wilo/server/notification/service/NotificationService.java
@@ -122,6 +122,11 @@ public class NotificationService {
         userNotificationRepository.delete(notification);
     }
 
+    @Transactional
+    public int deleteAllUserNotifications(Long receiverUserId) {
+        return userNotificationRepository.deleteAllByReceiverUserId(receiverUserId);
+    }
+
     private NotificationSummaryDto toDto(UserNotification notification) {
         String actorNickname = notification.getActorUser().getNickname();
         String message = switch (notification.getType()) {

--- a/src/test/java/com/wilo/server/community/CommunityControllerTest.java
+++ b/src/test/java/com/wilo/server/community/CommunityControllerTest.java
@@ -19,6 +19,7 @@ import com.wilo.server.community.repository.CommunityPostRepository;
 import com.wilo.server.global.config.security.jwt.JwtAuthentication;
 import com.wilo.server.user.entity.User;
 import com.wilo.server.user.repository.UserRepository;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -109,6 +110,7 @@ class CommunityControllerTest {
                 .andExpect(jsonPath("$.data.hasNext").value(true))
                 .andExpect(jsonPath("$.data.nextCursor").isNotEmpty())
                 .andReturn();
+        printPrettyResponse(firstPageResult);
 
         JsonNode firstPageJson = objectMapper.readTree(firstPageResult.getResponse().getContentAsString());
         String nextCursor = firstPageJson.path("data").path("nextCursor").asText();
@@ -143,6 +145,7 @@ class CommunityControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content").value("부모 댓글"))
                 .andReturn();
+        printPrettyResponse(parentResult);
 
         JsonNode parentJson = objectMapper.readTree(parentResult.getResponse().getContentAsString());
         long parentCommentId = parentJson.path("data").path("id").asLong();
@@ -316,6 +319,7 @@ class CommunityControllerTest {
                         .content("{\"content\":\"부모 댓글\"}"))
                 .andExpect(status().isOk())
                 .andReturn();
+        printPrettyResponse(parentResult);
         long parentId = objectMapper.readTree(parentResult.getResponse().getContentAsString()).path("data").path("id").asLong();
 
         MvcResult childResult = mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
@@ -326,6 +330,7 @@ class CommunityControllerTest {
                                 """.formatted(parentId)))
                 .andExpect(status().isOk())
                 .andReturn();
+        printPrettyResponse(childResult);
         long childId = objectMapper.readTree(childResult.getResponse().getContentAsString()).path("data").path("id").asLong();
 
         mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
@@ -348,5 +353,11 @@ class CommunityControllerTest {
                         .profileImageUrl("https://example.com/profile.png")
                         .build()
         );
+    }
+
+    private void printPrettyResponse(MvcResult result) throws Exception {
+        String json = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        System.out.println("==== API 응답 결과 ====");
+        System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(json)));
     }
 }

--- a/src/test/java/com/wilo/server/notification/NotificationControllerTest.java
+++ b/src/test/java/com/wilo/server/notification/NotificationControllerTest.java
@@ -325,6 +325,45 @@ class NotificationControllerTest {
                 .andExpect(jsonPath("$.errorCode").value(7002));
     }
 
+    @Test
+    void deleteAllUserNotifications_success() throws Exception {
+        User author = saveUser("delete-all-author@example.com", "deleteAllAuthor");
+        User commenter = saveUser("delete-all-commenter@example.com", "deleteAllCommenter");
+        User liker = saveUser("delete-all-liker@example.com", "deleteAllLiker");
+
+        CommunityPost post = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(author)
+                        .category(CommunityCategory.HELP_BRANCH)
+                        .title("전체 삭제 테스트")
+                        .content("본문")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
+                        .with(authentication(new JwtAuthentication(commenter.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"전체 삭제 댓글"}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/likes", post.getId())
+                        .with(authentication(new JwtAuthentication(liker.getId()))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(2));
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(0))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
     private User saveUser(String email, String nickname) {
         return userRepository.save(
                 User.builder()

--- a/src/test/java/com/wilo/server/notification/NotificationControllerTest.java
+++ b/src/test/java/com/wilo/server/notification/NotificationControllerTest.java
@@ -1,6 +1,7 @@
 package com.wilo.server.notification;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -243,6 +244,85 @@ class NotificationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.items.length()").value(0))
                 .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    void deleteNotification_success() throws Exception {
+        User author = saveUser("delete-author@example.com", "deleteAuthor");
+        User commenter = saveUser("delete-commenter@example.com", "deleteCommenter");
+
+        CommunityPost post = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(author)
+                        .category(CommunityCategory.TREE_SHADE)
+                        .title("삭제 테스트")
+                        .content("본문")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
+                        .with(authentication(new JwtAuthentication(commenter.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"삭제 대상 알림"}
+                                """))
+                .andExpect(status().isOk());
+
+        MvcResult listResult = mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andReturn();
+
+        long notificationId = objectMapper.readTree(listResult.getResponse().getContentAsString())
+                .path("data").path("items").get(0).path("id").asLong();
+
+        mockMvc.perform(delete("/api/v1/notifications/{notificationId}", notificationId)
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("success"));
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(0));
+    }
+
+    @Test
+    void deleteNotification_forOtherUsersNotification_forbidden() throws Exception {
+        User author = saveUser("delete-author2@example.com", "deleteAuthor2");
+        User commenter = saveUser("delete-commenter2@example.com", "deleteCommenter2");
+        User other = saveUser("delete-other@example.com", "deleteOther");
+
+        CommunityPost post = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(author)
+                        .category(CommunityCategory.SUNNY_PLACE)
+                        .title("삭제 권한 테스트")
+                        .content("본문")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
+                        .with(authentication(new JwtAuthentication(commenter.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"삭제 권한 확인"}
+                                """))
+                .andExpect(status().isOk());
+
+        MvcResult listResult = mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        long notificationId = objectMapper.readTree(listResult.getResponse().getContentAsString())
+                .path("data").path("items").get(0).path("id").asLong();
+
+        mockMvc.perform(delete("/api/v1/notifications/{notificationId}", notificationId)
+                        .with(authentication(new JwtAuthentication(other.getId()))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(7002));
     }
 
     private User saveUser(String email, String nickname) {

--- a/src/test/java/com/wilo/server/notification/NotificationControllerTest.java
+++ b/src/test/java/com/wilo/server/notification/NotificationControllerTest.java
@@ -1,0 +1,263 @@
+package com.wilo.server.notification;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wilo.server.community.entity.CommunityCategory;
+import com.wilo.server.community.entity.CommunityPost;
+import com.wilo.server.community.repository.CommunityCommentRepository;
+import com.wilo.server.community.repository.CommunityPostImageRepository;
+import com.wilo.server.community.repository.CommunityPostLikeRepository;
+import com.wilo.server.community.repository.CommunityPostRepository;
+import com.wilo.server.global.config.security.jwt.JwtAuthentication;
+import com.wilo.server.notification.repository.UserNotificationRepository;
+import com.wilo.server.user.entity.User;
+import com.wilo.server.user.repository.UserRepository;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CommunityPostRepository communityPostRepository;
+
+    @Autowired
+    private CommunityCommentRepository communityCommentRepository;
+
+    @Autowired
+    private CommunityPostLikeRepository communityPostLikeRepository;
+
+    @Autowired
+    private CommunityPostImageRepository communityPostImageRepository;
+
+    @Autowired
+    private UserNotificationRepository userNotificationRepository;
+
+    @BeforeEach
+    void setUp() {
+        communityCommentRepository.deleteAll();
+        communityPostLikeRepository.deleteAll();
+        communityPostImageRepository.deleteAll();
+        userNotificationRepository.deleteAll();
+        communityPostRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void getNotifications_latestAndCursorPagination_success() throws Exception {
+        User author = saveUser("author@example.com", "author");
+        User commenter = saveUser("commenter@example.com", "commenter");
+        User liker = saveUser("liker@example.com", "liker");
+
+        CommunityPost post = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(author)
+                        .category(CommunityCategory.TREE_SHADE)
+                        .title("알림 테스트")
+                        .content("본문")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
+                        .with(authentication(new JwtAuthentication(commenter.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"댓글 알림 내용입니다."}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/likes", post.getId())
+                        .with(authentication(new JwtAuthentication(liker.getId()))))
+                .andExpect(status().isOk());
+
+        MvcResult firstPage = mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId())))
+                        .param("size", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.items[0].type").value("POST_LIKE"))
+                .andExpect(jsonPath("$.data.items[0].postId").value(post.getId()))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.nextCursor").isNotEmpty())
+                .andReturn();
+        printPrettyResponse(firstPage);
+
+        JsonNode firstPageJson = objectMapper.readTree(firstPage.getResponse().getContentAsString());
+        String nextCursor = firstPageJson.path("data").path("nextCursor").asText();
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId())))
+                        .param("size", "1")
+                        .param("cursor", nextCursor))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.items[0].type").value("COMMENT"))
+                .andExpect(jsonPath("$.data.items[0].commentPreview").value("댓글 알림 내용입니다."))
+                .andExpect(jsonPath("$.data.items[0].postId").value(post.getId()))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    void markAsRead_and_markAllAsRead_success() throws Exception {
+        User author = saveUser("author2@example.com", "author2");
+        User commenter = saveUser("commenter2@example.com", "commenter2");
+        User liker = saveUser("liker2@example.com", "liker2");
+
+        CommunityPost post = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(author)
+                        .category(CommunityCategory.SUNNY_PLACE)
+                        .title("읽음 테스트")
+                        .content("본문")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
+                        .with(authentication(new JwtAuthentication(commenter.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"첫 댓글"}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/likes", post.getId())
+                        .with(authentication(new JwtAuthentication(liker.getId()))))
+                .andExpect(status().isOk());
+
+        MvcResult listResult = mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(2))
+                .andReturn();
+        printPrettyResponse(listResult);
+
+        JsonNode listJson = objectMapper.readTree(listResult.getResponse().getContentAsString());
+        long firstNotificationId = listJson.path("data").path("items").get(0).path("id").asLong();
+
+        mockMvc.perform(patch("/api/v1/notifications/{notificationId}/read", firstNotificationId)
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/v1/notifications/read-all")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(1));
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].isRead").value(true))
+                .andExpect(jsonPath("$.data.items[1].isRead").value(true));
+    }
+
+    @Test
+    void markAsRead_forOtherUsersNotification_forbidden() throws Exception {
+        User author = saveUser("author3@example.com", "author3");
+        User commenter = saveUser("commenter3@example.com", "commenter3");
+        User other = saveUser("other3@example.com", "other3");
+
+        CommunityPost post = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(author)
+                        .category(CommunityCategory.HELP_BRANCH)
+                        .title("권한 테스트")
+                        .content("본문")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
+                        .with(authentication(new JwtAuthentication(commenter.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"권한 확인"}
+                                """))
+                .andExpect(status().isOk());
+
+        MvcResult listResult = mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andReturn();
+        printPrettyResponse(listResult);
+
+        JsonNode listJson = objectMapper.readTree(listResult.getResponse().getContentAsString());
+        long notificationId = listJson.path("data").path("items").get(0).path("id").asLong();
+
+        mockMvc.perform(patch("/api/v1/notifications/{notificationId}/read", notificationId)
+                        .with(authentication(new JwtAuthentication(other.getId()))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(7002));
+    }
+
+    @Test
+    void selfCommentAndLike_doNotCreateNotifications() throws Exception {
+        User author = saveUser("self@example.com", "selfUser");
+        CommunityPost post = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(author)
+                        .category(CommunityCategory.SUPPORT_ROOT)
+                        .title("셀프 알림 없음")
+                        .content("본문")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post.getId())
+                        .with(authentication(new JwtAuthentication(author.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"내가 단 댓글"}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/likes", post.getId())
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(new JwtAuthentication(author.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(0))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    private User saveUser(String email, String nickname) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password("encoded-password")
+                        .nickname(nickname)
+                        .build()
+        );
+    }
+
+    private void printPrettyResponse(MvcResult result) throws Exception {
+        String json = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        System.out.println("==== API 응답 결과 ====");
+        System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(json)));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #30 

## 📝 작업 내용

- 알림 관련 CRUD 구현 완료
- 알림 기능 테스트 코드 작성 완료

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 시스템 추가: 다른 사용자가 게시물에 댓글을 달거나 좋아요를 누르면 알림을 받습니다.
  * 커서 기반 페이지네이션을 통한 알림 목록 조회 기능 추가
  * 알림을 개별 또는 일괄로 읽음 표시하는 기능 추가
  * 알림을 개별 또는 일괄 삭제하는 기능 추가

* **테스트**
  * 알림 시스템 포괄적 테스트 스위트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->