### PR TITLE
[REFACTOR] AI 대화 요약 로직 리팩토링 및 세션 삭제 API 구현 

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/client/RealAiSummarizeClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiSummarizeClient.java
@@ -34,19 +34,36 @@ public class RealAiSummarizeClient implements AiSummarizeClient {
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(req)
                 .retrieve()
+
+                // 5xx → retry 대상
                 .onStatus(HttpStatusCode::is5xxServerError,
                         r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED)))
+
+                // 4xx → retry 대상 아님
                 .onStatus(HttpStatusCode::is4xxClientError,
                         r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID)))
+
                 .bodyToMono(AiSummarizeResponse.class)
+
+                // AI 명세 timeout = 60초
                 .timeout(Duration.ofSeconds(60))
+
+                // retry 1회
                 .retryWhen(
-                        Retry.max(1).filter(ex -> ex instanceof java.util.concurrent.TimeoutException
-                                        || ex instanceof ApplicationException).transientErrors(true)
+                        Retry.max(1)
+                                .filter(ex ->
+                                        ex instanceof java.util.concurrent.TimeoutException
+                                                || ex instanceof org.springframework.web.reactive.function.client.WebClientRequestException
+                                                || (ex instanceof ApplicationException
+                                                && ((ApplicationException) ex).getErrorCase() == ChatbotErrorCase.AI_SERVER_FAILED)
+                                )
                 )
+
                 .onErrorMap(java.util.concurrent.TimeoutException.class,
-                        ex -> new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED))
+                        ex -> new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED)
+                )
                 .block();
+
 
         if (res == null) {
             throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiSummarizeClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiSummarizeClient.java
@@ -62,6 +62,9 @@ public class RealAiSummarizeClient implements AiSummarizeClient {
                 .onErrorMap(java.util.concurrent.TimeoutException.class,
                         ex -> new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED)
                 )
+                .onErrorMap(org.springframework.web.reactive.function.client.WebClientRequestException.class,
+                        ex -> new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED)
+                )
                 .block();
 
 

--- a/src/main/java/com/wilo/server/chatbot/client/dto/AiSummarizeRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/client/dto/AiSummarizeRequest.java
@@ -11,4 +11,13 @@ import java.util.List;
 @Builder
 public class AiSummarizeRequest {
     private List<AiRoleMessage> messages;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Message {
+        private String role;
+        private String content;
+    }
 }

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -1,6 +1,7 @@
 package com.wilo.server.chatbot.controller;
 
 import com.wilo.server.chatbot.dto.*;
+import com.wilo.server.chatbot.service.ChatSessionDeleteService;
 import com.wilo.server.chatbot.service.ChatSessionService;
 import com.wilo.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +26,7 @@ import java.time.LocalDateTime;
 public class ChatSessionController {
 
     private final ChatSessionService chatSessionService;
+    private final ChatSessionDeleteService chatSessionDeleteService;
 
     @PostMapping
     @Operation(
@@ -208,5 +210,32 @@ public class ChatSessionController {
             @RequestHeader(value = "X-Guest-Id", required = false) String guestId
     ) {
         return CommonResponse.success(chatSessionService.restoreSession(sessionId, guestId));
+    }
+
+
+    @DeleteMapping
+    @Operation(
+            summary = "세션 삭제(선택 삭제)",
+            description = """
+                사용자가 선택한 대화 세션과 해당 세션의 메시지 데이터를 영구 삭제합니다.
+                - 로그인 사용자는 JWT userId 기준
+                - 비로그인 사용자는 X-Guest-Id 기준
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "삭제할 세션이 올바르지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatSessionDeleteResponse> deleteSessions(
+            @Parameter(description = "비로그인 사용자 UUID. 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId,
+            @Valid @RequestBody ChatSessionDeleteRequest request
+    ) {
+        return CommonResponse.success(chatSessionDeleteService.deleteSessions(guestId, request));
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionDeleteRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionDeleteRequest.java
@@ -1,0 +1,12 @@
+package com.wilo.server.chatbot.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ChatSessionDeleteRequest {
+    @NotEmpty
+    private List<Long> sessionIds;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionDeleteResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatSessionDeleteResponse {
+    private int deletedCount;
+
+    public static ChatSessionDeleteResponse of(int deletedCount) {
+        return ChatSessionDeleteResponse.builder()
+                .deletedCount(deletedCount)
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -14,10 +14,10 @@ public enum ChatbotErrorCase implements ErrorCase {
     GUEST_ID_REQUIRED(400, 3004, "비로그인 사용자는 X-Guest-Id 헤더가 필요합니다."),
     SESSION_FORBIDDEN(403, 3005, "접근 권한이 없습니다."),
     SESSION_NOT_FOUND(404, 3006, "대화 세션을 찾을 수 없습니다."),
-    TITLE_INVALID(400, 3007, "제목이 정책을 충족하지 않습니다."),
-    AI_SERVER_FAILED(502, 3008, "AI 서버 응답에 실패했습니다."),
-    AI_RESPONSE_INVALID(502, 3009, "AI 응답 형식이 올바르지 않습니다.");
-
+    SESSION_DELETE_INVALID(400,3007, "삭제할 세션이 올바르지 않습니다."),
+    TITLE_INVALID(400, 3008, "제목이 정책을 충족하지 않습니다."),
+    AI_SERVER_FAILED(502, 3009, "AI 서버 응답에 실패했습니다."),
+    AI_RESPONSE_INVALID(502, 3010, "AI 응답 형식이 올바르지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -49,7 +49,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     List<ChatMessage> findAllForSummary(
             @Param("sessionId") Long sessionId
     );
-    
+
     // 유지할 메시지 기준 ID 조회
     @Query("""
         select m.id

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
@@ -73,4 +74,12 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             @Param("sessionId") Long sessionId,
             @Param("keepFromId") Long keepFromId
     );
+
+    // 세션 ID 목록으로 메시지 삭제
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        delete from ChatMessage m
+        where m.sessionId in :sessionIds
+    """)
+    int deleteBySessionIds(@Param("sessionIds") Collection<Long> sessionIds);
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
+    // 메시지 목록 조회 (커서 기반 페이징)
     @Query("""
         select m
         from ChatMessage m
@@ -24,27 +25,52 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             Pageable pageable
     );
 
+
+    // 최근 메시지 N개 조회 (AI chat용)
     @Query("""
         select m
         from ChatMessage m
         where m.sessionId = :sessionId
         order by m.id desc
     """)
-    List<ChatMessage> findRecentDesc(@Param("sessionId") Long sessionId, Pageable pageable);
+    List<ChatMessage> findRecentDesc(
+            @Param("sessionId") Long sessionId,
+            Pageable pageable
+    );
 
+
+    // 요약 생성용 전체 메시지 조회
     @Query("""
         select m
         from ChatMessage m
         where m.sessionId = :sessionId
         order by m.id asc
     """)
-    List<ChatMessage> findOldestAsc(@Param("sessionId") Long sessionId, Pageable pageable);
+    List<ChatMessage> findAllForSummary(
+            @Param("sessionId") Long sessionId
+    );
+    
+    // 유지할 메시지 기준 ID 조회
+    @Query("""
+        select m.id
+        from ChatMessage m
+        where m.sessionId = :sessionId
+        order by m.id desc
+    """)
+    List<Long> findRecentIds(
+            @Param("sessionId") Long sessionId,
+            Pageable pageable
+    );
 
+    // 오래된 메시지 삭제
     @Modifying(clearAutomatically = true)
     @Query("""
         delete from ChatMessage m
         where m.sessionId = :sessionId
           and m.id < :keepFromId
     """)
-    int deleteOlderThan(@Param("sessionId") Long sessionId, @Param("keepFromId") Long keepFromId);
+    int deleteOlderThan(
+            @Param("sessionId") Long sessionId,
+            @Param("keepFromId") Long keepFromId
+    );
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionMemoryRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionMemoryRepository.java
@@ -3,5 +3,9 @@ package com.wilo.server.chatbot.repository;
 import com.wilo.server.chatbot.entity.ChatSessionMemory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatSessionMemoryRepository extends JpaRepository<ChatSessionMemory, Long> {
+    Optional<ChatSessionMemory> findBySessionId(Long sessionId);
+    boolean existsBySessionId(Long sessionId);
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionMemoryRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionMemoryRepository.java
@@ -2,10 +2,21 @@ package com.wilo.server.chatbot.repository;
 
 import com.wilo.server.chatbot.entity.ChatSessionMemory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface ChatSessionMemoryRepository extends JpaRepository<ChatSessionMemory, Long> {
     Optional<ChatSessionMemory> findBySessionId(Long sessionId);
     boolean existsBySessionId(Long sessionId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        delete from ChatSessionMemory m
+        where m.sessionId in :sessionIds
+    """)
+    int deleteBySessionIds(@Param("sessionIds") Collection<Long> sessionIds);
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
@@ -4,10 +4,12 @@ import com.wilo.server.chatbot.entity.ChatSession;
 import com.wilo.server.chatbot.entity.ChatSessionStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,4 +51,26 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
     Optional<ChatSession> findByIdWithChatbotType(
             @Param("sessionId") Long sessionId
     );
+
+    @Query("""
+        select s.id
+        from ChatSession s
+        where s.id in :ids
+          and (
+            (:userId is not null and s.userId = :userId)
+            or (:userId is null and :guestId is not null and s.guestId = :guestId)
+          )
+    """)
+    List<Long> findOwnedSessionIds(
+            @Param("ids") Collection<Long> ids,
+            @Param("userId") Long userId,
+            @Param("guestId") String guestId
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        delete from ChatSession s
+        where s.id in :ids
+    """)
+    int deleteByIds(@Param("ids") Collection<Long> ids);
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
@@ -63,7 +63,11 @@ public class ChatMessageService {
 
         ChatMessage savedBot = chatMessageTxService.saveBotMessageWithSessionUpdate(sessionId, aiResult);
 
-        chatSummaryService.summarizeIfNeeded(sessionId); // AI 대화 내용 요약 자동 실행
+        try {
+            chatSummaryService.summarizeIfNeeded(sessionId); // 후처리
+        } catch (Exception e) {
+            log.warn("요약 후처리 실패 sessionId={}", sessionId, e);
+        }
 
         return ChatMessageSendResponse.builder()
                 .sessionId(sessionId)

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageService.java
@@ -20,6 +20,7 @@ public class ChatMessageService {
 
     private final AiChatClient aiChatClient;
     private final ChatMessageTxService chatMessageTxService;
+    private final ChatSummaryService chatSummaryService;
 
     public ChatMessageSendResponse sendMessage(Long sessionId, String guestIdHeader, ChatMessageSendRequest request) {
 
@@ -61,6 +62,8 @@ public class ChatMessageService {
         }
 
         ChatMessage savedBot = chatMessageTxService.saveBotMessageWithSessionUpdate(sessionId, aiResult);
+
+        chatSummaryService.summarizeIfNeeded(sessionId); // AI 대화 내용 요약 자동 실행
 
         return ChatMessageSendResponse.builder()
                 .sessionId(sessionId)

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionDeleteService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionDeleteService.java
@@ -1,0 +1,77 @@
+package com.wilo.server.chatbot.service;
+
+import com.wilo.server.chatbot.dto.ChatSessionDeleteRequest;
+import com.wilo.server.chatbot.dto.ChatSessionDeleteResponse;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatMessageRepository;
+import com.wilo.server.chatbot.repository.ChatSessionMemoryRepository;
+import com.wilo.server.chatbot.repository.ChatSessionRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatSessionDeleteService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatSessionMemoryRepository chatSessionMemoryRepository;
+
+    @Transactional
+    public ChatSessionDeleteResponse deleteSessions(String guestIdHeader, ChatSessionDeleteRequest request) {
+
+        Long userId = extractUserIdIfAuthenticated();
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (userId == null && guestId == null) {
+            // 게스트 요청이면 guestId 필수
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        List<Long> sessionIds = request.getSessionIds();
+        if (sessionIds == null || sessionIds.isEmpty()) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_DELETE_INVALID);
+        }
+
+        var uniqueIds = new HashSet<Long>();
+        for (Long id : sessionIds) {
+            if (id == null || id <= 0) {
+                throw new ApplicationException(ChatbotErrorCase.SESSION_DELETE_INVALID);
+            }
+            uniqueIds.add(id);
+        }
+
+        // 소유권 검증
+        List<Long> ownedIds = chatSessionRepository.findOwnedSessionIds(uniqueIds, userId, guestId);
+        if (ownedIds.size() != uniqueIds.size()) {
+            throw new ApplicationException(ChatbotErrorCase.SESSION_DELETE_INVALID);
+        }
+
+        chatMessageRepository.deleteBySessionIds(uniqueIds);
+        chatSessionMemoryRepository.deleteBySessionIds(uniqueIds);
+
+        // 세션 삭제
+        int deletedCount = chatSessionRepository.deleteByIds(uniqueIds);
+
+        return ChatSessionDeleteResponse.of(deletedCount);
+    }
+
+    private String normalizeGuestId(String guestIdHeader) {
+        if (guestIdHeader == null) return null;
+        String trimmed = guestIdHeader.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private Long extractUserIdIfAuthenticated() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) return null;
+        if (auth.getPrincipal() instanceof Long userId) return userId;
+        return null;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSummaryService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSummaryService.java
@@ -65,6 +65,10 @@ public class ChatSummaryService {
             throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED, e);
         }
 
+        if (result == null) {
+            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+        }
+
         String summary = (result.getSummary() == null) ? "" : result.getSummary().trim();
         List<String> keyTopics = (result.getKeyTopics() == null) ? List.of() : result.getKeyTopics();
 

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSummaryService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSummaryService.java
@@ -6,101 +6,133 @@ import com.wilo.server.chatbot.client.AiSummarizeResult;
 import com.wilo.server.chatbot.client.dto.AiRoleMessage;
 import com.wilo.server.chatbot.entity.ChatMessage;
 import com.wilo.server.chatbot.entity.ChatSessionMemory;
-import com.wilo.server.chatbot.entity.SenderType;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
 import com.wilo.server.chatbot.repository.ChatMessageRepository;
 import com.wilo.server.chatbot.repository.ChatSessionMemoryRepository;
+import com.wilo.server.global.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatSummaryService {
-
-    private static final int KEEP_RECENT_N = 30;     // 최근 N턴 유지
-    private static final int SUMMARIZE_BATCH = 1000; // 요약할 최대 raw 수
+    private static final int KEEP_LAST_MESSAGES = 30;        // DB에 남길 최근 raw 개수
+    private static final int SUMMARIZE_TRIGGER_COUNT = 40;   // raw가 이 이상이면 요약 돌림
 
     private final ChatMessageRepository chatMessageRepository;
     private final ChatSessionMemoryRepository chatSessionMemoryRepository;
     private final AiSummarizeClient aiSummarizeClient;
     private final ObjectMapper objectMapper;
 
-    // 세션 만료 시 호출
+    // 메시지 수가 충분히 쌓였으면 요약 생성 + 오래된 raw 삭제
     @Transactional
-    public void summarizeAndPrune(Long sessionId) {
-
-        // 최신 KEEP_RECENT_N개를 남기기 위해, 최신 N개 중 가장 작은 id를 keepFromId로 사용
-        List<ChatMessage> recentDesc = chatMessageRepository.findRecentDesc(
-                sessionId,
-                PageRequest.of(0, KEEP_RECENT_N)
+    public void summarizeIfNeeded(Long sessionId) {
+        List<Long> probe = chatMessageRepository.findRecentIds(
+                sessionId, PageRequest.of(0, SUMMARIZE_TRIGGER_COUNT)
         );
 
-        if (recentDesc.isEmpty()) {
+        if (probe.size() < SUMMARIZE_TRIGGER_COUNT) {
             return;
         }
 
-        Long keepFromId = recentDesc.stream()
-                .map(ChatMessage::getId)
-                .min(Long::compareTo)
-                .orElse(null);
+        summarizeAndTrim(sessionId);
+    }
 
-        // keepFromId 이전의 오래된 메시지들을 요약 대상으로 수집 (DB에 오래된 메시지가 많이 쌓이지 않도록 상한 설정)
-        List<ChatMessage> oldestAsc = chatMessageRepository.findOldestAsc(sessionId, PageRequest.of(0, SUMMARIZE_BATCH));
+    // 강제 요약 (세션 만료 시 호출)
+    @Transactional
+    public void summarizeAndTrim(Long sessionId) {
 
-        // 전체가 KEEP_RECENT_N 이하라면 prune/요약 스킵
-        if (oldestAsc.size() <= KEEP_RECENT_N) {
-            return;
+        List<ChatMessage> all = chatMessageRepository.findAllForSummary(sessionId);
+        if (all.isEmpty()) return;
+
+        // AI로 보낼 messages 구성
+        List<AiRoleMessage> toSummarize = buildSummarizeInput(sessionId, all);
+        if (toSummarize.isEmpty()) return;
+
+        // AI summarize 호출
+        AiSummarizeResult result;
+        try {
+            result = aiSummarizeClient.summarize(toSummarize);
+        } catch (Exception e) {
+            log.error("summarize failed sessionId={}", sessionId, e);
+            throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED, e);
         }
 
-        // 요약 대상 = keepFromId 미만
-        List<ChatMessage> toSummarize = oldestAsc.stream()
-                .filter(m -> m.getId() < keepFromId)
-                .toList();
+        String summary = (result.getSummary() == null) ? "" : result.getSummary().trim();
+        List<String> keyTopics = (result.getKeyTopics() == null) ? List.of() : result.getKeyTopics();
 
-        if (toSummarize.isEmpty()) {
-            return;
-        }
-
-        // role+content만 전달
-        List<AiRoleMessage> aiMsgs = toSummarize.stream()
-                .map(m -> AiRoleMessage.builder()
-                        .role(m.getSenderType() == SenderType.USER ? "user" : "assistant")
-                        .content(m.getContent()) // TODO: PII sanitizer 적용
-                        .build())
-                .toList();
-
-        AiSummarizeResult result = aiSummarizeClient.summarize(aiMsgs);
-
-        // 빈 입력이면 summary="" 내려올 수 있음. 빈 요약이면 저장 스킵
-        if (result.getSummary() == null || result.getSummary().isBlank()) {
-            log.info("summarize empty sessionId={}", sessionId);
+        // summary 비어있으면 저장 스킵
+        if (summary.isBlank()) {
             return;
         }
 
         String keyTopicsJson;
         try {
-            keyTopicsJson = objectMapper.writeValueAsString(result.getKeyTopics());
+            keyTopicsJson = objectMapper.writeValueAsString(keyTopics);
         } catch (Exception e) {
-            log.warn("keyTopics 직렬화 실패 sessionId={}", sessionId, e);
-            keyTopicsJson = "[]";
+            throw new ApplicationException(ChatbotErrorCase.CHATBOT_INTERNAL_SERVER_ERROR, e);
         }
 
-        ChatSessionMemory mem = chatSessionMemoryRepository.findById(sessionId).orElse(null);
-        if (mem == null) {
-            chatSessionMemoryRepository.save(
-                    ChatSessionMemory.upsert(sessionId, result.getSummary(), keyTopicsJson)
-            );
-        } else {
-            mem.update(result.getSummary(), keyTopicsJson);
+        ChatSessionMemory memory = chatSessionMemoryRepository.findById(sessionId)
+                .orElseGet(() -> ChatSessionMemory.upsert(sessionId, "", "[]"));
+
+        memory.update(summary, keyTopicsJson);
+        chatSessionMemoryRepository.save(memory);
+
+        // 오래된 raw 삭제 (최근 KEEP_LAST_MESSAGES만 유지)
+        trimOldMessages(sessionId);
+    }
+
+    private List<AiRoleMessage> buildSummarizeInput(Long sessionId, List<ChatMessage> allAsc) {
+
+        String previousSummary = chatSessionMemoryRepository.findById(sessionId)
+                .map(ChatSessionMemory::getSummary)
+                .orElse("");
+
+        List<AiRoleMessage> out = new ArrayList<>();
+
+        if (previousSummary != null && !previousSummary.isBlank()) {
+            out.add(AiRoleMessage.builder()
+                    .role("system")
+                    .content("이전 세션 요약: " + previousSummary)
+                    .build());
         }
 
-        // 오래된 raw 삭제
-        int deleted = chatMessageRepository.deleteOlderThan(sessionId, keepFromId);
-        log.info("prune sessionId={} keepFromId={} deleted={}", sessionId, keepFromId, deleted);
+        for (ChatMessage m : allAsc) {
+            if (m.getContent() == null || m.getContent().isBlank()) continue;
+
+            String role = (m.getSenderType().name().equals("USER")) ? "user" : "assistant";
+
+            out.add(AiRoleMessage.builder()
+                    .role(role)
+                    .content(m.getContent())
+                    .build());
+        }
+
+        return out;
+    }
+
+    private void trimOldMessages(Long sessionId) {
+
+        // 최근 KEEP_LAST_MESSAGES개의 가장 오래된 id를 구해서, 그보다 작은 것들을 전부 삭제
+        List<Long> recentIds = chatMessageRepository.findRecentIds(
+                sessionId, PageRequest.of(0, KEEP_LAST_MESSAGES)
+        );
+
+        if (recentIds.size() < KEEP_LAST_MESSAGES) {
+            return;
+        }
+
+        Long keepFromId = recentIds.get(recentIds.size() - 1);
+
+        // keepFromId 보다 작은 것들 삭제
+        chatMessageRepository.deleteOlderThan(sessionId, keepFromId);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #32 

## 📝 작업 내용
**1. AI 요약 생성 호출 로직 리팩토링**
세션 메시지가 일정 개수 이상 누적되었을 때 AI 서버 /summarize API를 호출하여 요약을 생성하도록 리팩토링 진행했습니다.

주요 기능
```
/summarize API 연동
role + content 형태로 AI 서버 전달
기존 summary가 존재할 경우 누적 요약 형태로 전달
summary 및 key_topics 저장
요약 이후 오래된 메시지 삭제

```
**2. 세션 삭제 API 구현**
- 사용자가 선택한 세션과 메시지를 영구 삭제하는 API를 구현했습니다.

## 🖼️ 스크린샷 (선택)
### 세션 삭제 성공
<img width="1470" height="943" alt="화면 캡처 2026-03-02 000251" src="https://github.com/user-attachments/assets/de63762c-ce8c-4124-9b2b-26f4e3ca6470" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 세션 선택 삭제 REST API 및 배치 삭제 기능 추가
  * 대화 요약 트리거 및 전체 요약 실행 기능 추가

* **버그 수정**
  * AI 요약 호출의 5xx/타임아웃/네트워크 오류에 대한 재시도 및 오류 매핑 개선 (60초 타임아웃 포함)

* **개선 사항**
  * 자동 요약 후 오래된 메시지 정리 및 요약/메모리 저장 흐름 강화
  * 오류 코드 및 삭제 관련 검증/응답 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->