### PR TITLE
[FEAT] 유저-커뮤니티 조회 api 구현

### DIFF
--- a/src/main/java/com/wilo/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/wilo/server/auth/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/chatbot-types/**").permitAll()
                                 .requestMatchers("/api/v1/chat/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/community/posts/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/community/users/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(sessionManagement ->

--- a/src/main/java/com/wilo/server/community/controller/CommunityController.java
+++ b/src/main/java/com/wilo/server/community/controller/CommunityController.java
@@ -8,6 +8,7 @@ import com.wilo.server.community.dto.CommunityPostCreateRequestDto;
 import com.wilo.server.community.dto.CommunityPostDetailResponseDto;
 import com.wilo.server.community.dto.CommunityPostListResponseDto;
 import com.wilo.server.community.dto.CommunityPostUpdateRequestDto;
+import com.wilo.server.community.dto.CommunityUserCommentListResponseDto;
 import com.wilo.server.community.entity.CommunityCategory;
 import com.wilo.server.community.entity.CommunityPostSortType;
 import com.wilo.server.community.service.CommunityService;
@@ -175,6 +176,30 @@ public class CommunityController {
             @RequestParam(defaultValue = "20") Integer size
     ) {
         return CommonResponse.success(communityService.getPostsByAuthor(userId, cursor, size));
+    }
+
+    @GetMapping("/users/{userId}/comments")
+    @Operation(
+            summary = "특정 유저 작성 댓글 조회",
+            description = "특정 유저가 작성한 댓글을 최신순(createdAt desc, id desc)으로 커서 페이지네이션 조회합니다. "
+                    + "첫 페이지는 cursor 없이 요청하고, 다음 페이지는 응답의 nextCursor를 cursor로 전달하세요."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "파라미터 오류(size/cursor)"
+            )
+    })
+    public CommonResponse<CommunityUserCommentListResponseDto> getCommentsByAuthor(
+            @Parameter(description = "조회할 작성자 유저 ID")
+            @PathVariable Long userId,
+            @Parameter(description = "커서 값. 포맷: createdAt|id (예: 2026-03-01T12:30:00|123)")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "페이지 크기. 기본값 20, 최대 50")
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        return CommonResponse.success(communityService.getCommentsByAuthor(userId, cursor, size));
     }
 
     @GetMapping("/posts/{postId}")

--- a/src/main/java/com/wilo/server/community/controller/CommunityController.java
+++ b/src/main/java/com/wilo/server/community/controller/CommunityController.java
@@ -202,6 +202,30 @@ public class CommunityController {
         return CommonResponse.success(communityService.getCommentsByAuthor(userId, cursor, size));
     }
 
+    @GetMapping("/users/{userId}/liked-posts")
+    @Operation(
+            summary = "특정 유저 좋아요 게시글 조회",
+            description = "특정 유저가 좋아요한 게시글을 좋아요 시각 최신순(createdAt desc, id desc)으로 커서 페이지네이션 조회합니다. "
+                    + "첫 페이지는 cursor 없이 요청하고, 다음 페이지는 응답의 nextCursor를 cursor로 전달하세요."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "파라미터 오류(size/cursor)"
+            )
+    })
+    public CommonResponse<CommunityPostListResponseDto> getLikedPostsByUser(
+            @Parameter(description = "조회할 유저 ID")
+            @PathVariable Long userId,
+            @Parameter(description = "커서 값. 포맷: createdAt|id (예: 2026-03-01T12:30:00|123)")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "페이지 크기. 기본값 20, 최대 50")
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        return CommonResponse.success(communityService.getLikedPostsByUser(userId, cursor, size));
+    }
+
     @GetMapping("/posts/{postId}")
     @Operation(summary = "게시글 상세 조회", description = "게시글 상세 정보(작성자, 이미지, 댓글/답글)를 조회하고 조회수를 증가시킵니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/wilo/server/community/controller/CommunityController.java
+++ b/src/main/java/com/wilo/server/community/controller/CommunityController.java
@@ -153,6 +153,30 @@ public class CommunityController {
         return CommonResponse.success(communityService.getPosts(category, sort, keyword, cursor, size));
     }
 
+    @GetMapping("/users/{userId}/posts")
+    @Operation(
+            summary = "특정 유저 작성 게시글 조회",
+            description = "특정 유저가 작성한 게시글을 최신순(createdAt desc, id desc)으로 커서 페이지네이션 조회합니다. "
+                    + "첫 페이지는 cursor 없이 요청하고, 다음 페이지는 응답의 nextCursor를 cursor로 전달하세요."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "파라미터 오류(size/cursor)"
+            )
+    })
+    public CommonResponse<CommunityPostListResponseDto> getPostsByAuthor(
+            @Parameter(description = "조회할 작성자 유저 ID")
+            @PathVariable Long userId,
+            @Parameter(description = "커서 값. 포맷: createdAt|id (예: 2026-03-01T12:30:00|123)")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "페이지 크기. 기본값 20, 최대 50")
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        return CommonResponse.success(communityService.getPostsByAuthor(userId, cursor, size));
+    }
+
     @GetMapping("/posts/{postId}")
     @Operation(summary = "게시글 상세 조회", description = "게시글 상세 정보(작성자, 이미지, 댓글/답글)를 조회하고 조회수를 증가시킵니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/wilo/server/community/dto/CommunityUserCommentListResponseDto.java
+++ b/src/main/java/com/wilo/server/community/dto/CommunityUserCommentListResponseDto.java
@@ -1,0 +1,12 @@
+package com.wilo.server.community.dto;
+
+import java.util.List;
+
+public record CommunityUserCommentListResponseDto(
+        List<CommunityUserCommentSummaryDto> items,
+        String cursor,
+        int size,
+        boolean hasNext,
+        String nextCursor
+) {
+}

--- a/src/main/java/com/wilo/server/community/dto/CommunityUserCommentSummaryDto.java
+++ b/src/main/java/com/wilo/server/community/dto/CommunityUserCommentSummaryDto.java
@@ -1,0 +1,13 @@
+package com.wilo.server.community.dto;
+
+import java.time.LocalDateTime;
+
+public record CommunityUserCommentSummaryDto(
+        Long id,
+        Long postId,
+        String postTitle,
+        String content,
+        LocalDateTime createdAt,
+        long daysAgo
+) {
+}

--- a/src/main/java/com/wilo/server/community/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/CommunityCommentRepository.java
@@ -1,10 +1,11 @@
 package com.wilo.server.community.repository;
 
 import com.wilo.server.community.entity.CommunityComment;
+import com.wilo.server.community.repository.query.CommunityCommentQueryRepository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
+public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long>, CommunityCommentQueryRepository {
 
     List<CommunityComment> findByPostIdOrderByCreatedAtAscIdAsc(Long postId);
 }

--- a/src/main/java/com/wilo/server/community/repository/CommunityPostLikeRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/CommunityPostLikeRepository.java
@@ -1,11 +1,12 @@
 package com.wilo.server.community.repository;
 
 import com.wilo.server.community.entity.CommunityPostLike;
+import com.wilo.server.community.repository.query.CommunityPostLikeQueryRepository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommunityPostLikeRepository extends JpaRepository<CommunityPostLike, Long> {
+public interface CommunityPostLikeRepository extends JpaRepository<CommunityPostLike, Long>, CommunityPostLikeQueryRepository {
 
     boolean existsByPostIdAndUserId(Long postId, Long userId);
 

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityCommentQueryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityCommentQueryRepository.java
@@ -1,0 +1,16 @@
+package com.wilo.server.community.repository.query;
+
+import com.wilo.server.community.entity.CommunityComment;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface CommunityCommentQueryRepository {
+
+    List<CommunityComment> findLatestByUserIdCursor(
+            Long userId,
+            LocalDateTime cursorCreatedAt,
+            Long cursorId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityCommentQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityCommentQueryRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.wilo.server.community.repository.query;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wilo.server.community.entity.CommunityComment;
+import com.wilo.server.community.entity.QCommunityComment;
+import com.wilo.server.community.entity.QCommunityPost;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunityCommentQueryRepositoryImpl implements CommunityCommentQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QCommunityComment comment = QCommunityComment.communityComment;
+    private static final QCommunityPost post = QCommunityPost.communityPost;
+
+    @Override
+    public List<CommunityComment> findLatestByUserIdCursor(
+            Long userId,
+            LocalDateTime cursorCreatedAt,
+            Long cursorId,
+            Pageable pageable
+    ) {
+        return queryFactory
+                .selectFrom(comment)
+                .join(comment.post, post).fetchJoin()
+                .where(
+                        comment.user.id.eq(userId),
+                        cursorCondition(cursorCreatedAt, cursorId)
+                )
+                .orderBy(comment.createdAt.desc(), comment.id.desc())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private BooleanExpression cursorCondition(LocalDateTime cursorCreatedAt, Long cursorId) {
+        if (cursorCreatedAt == null || cursorId == null) {
+            return null;
+        }
+
+        return comment.createdAt.lt(cursorCreatedAt)
+                .or(comment.createdAt.eq(cursorCreatedAt).and(comment.id.lt(cursorId)));
+    }
+}

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityPostLikeQueryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityPostLikeQueryRepository.java
@@ -1,0 +1,16 @@
+package com.wilo.server.community.repository.query;
+
+import com.wilo.server.community.entity.CommunityPostLike;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface CommunityPostLikeQueryRepository {
+
+    List<CommunityPostLike> findLikedPostsByUserIdCursor(
+            Long userId,
+            LocalDateTime cursorCreatedAt,
+            Long cursorId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityPostLikeQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityPostLikeQueryRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.wilo.server.community.repository.query;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wilo.server.community.entity.CommunityPostLike;
+import com.wilo.server.community.entity.QCommunityPost;
+import com.wilo.server.community.entity.QCommunityPostLike;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunityPostLikeQueryRepositoryImpl implements CommunityPostLikeQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QCommunityPostLike postLike = QCommunityPostLike.communityPostLike;
+    private static final QCommunityPost post = QCommunityPost.communityPost;
+
+    @Override
+    public List<CommunityPostLike> findLikedPostsByUserIdCursor(
+            Long userId,
+            LocalDateTime cursorCreatedAt,
+            Long cursorId,
+            Pageable pageable
+    ) {
+        return queryFactory
+                .selectFrom(postLike)
+                .join(postLike.post, post).fetchJoin()
+                .where(
+                        postLike.user.id.eq(userId),
+                        cursorCondition(cursorCreatedAt, cursorId)
+                )
+                .orderBy(postLike.createdAt.desc(), postLike.id.desc())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private BooleanExpression cursorCondition(LocalDateTime cursorCreatedAt, Long cursorId) {
+        if (cursorCreatedAt == null || cursorId == null) {
+            return null;
+        }
+
+        return postLike.createdAt.lt(cursorCreatedAt)
+                .or(postLike.createdAt.eq(cursorCreatedAt).and(postLike.id.lt(cursorId)));
+    }
+}

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityPostQueryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityPostQueryRepository.java
@@ -24,4 +24,11 @@ public interface CommunityPostQueryRepository {
             Long cursorId,
             Pageable pageable
     );
+
+    List<CommunityPost> findLatestPostsByAuthorCursor(
+            Long authorUserId,
+            LocalDateTime cursorCreatedAt,
+            Long cursorId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityPostQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityPostQueryRepositoryImpl.java
@@ -60,6 +60,24 @@ public class CommunityPostQueryRepositoryImpl implements CommunityPostQueryRepos
                 .fetch();
     }
 
+    @Override
+    public List<CommunityPost> findLatestPostsByAuthorCursor(
+            Long authorUserId,
+            LocalDateTime cursorCreatedAt,
+            Long cursorId,
+            Pageable pageable
+    ) {
+        return queryFactory
+                .selectFrom(post)
+                .where(
+                        authorUserIdEq(authorUserId),
+                        latestCursorCondition(cursorCreatedAt, cursorId)
+                )
+                .orderBy(post.createdAt.desc(), post.id.desc())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
     private BooleanExpression categoryEq(CommunityCategory category) {
         if (category == null) {
             return null;
@@ -75,6 +93,13 @@ public class CommunityPostQueryRepositoryImpl implements CommunityPostQueryRepos
         String normalized = keyword.toLowerCase();
         return post.title.lower().contains(normalized)
                 .or(post.content.lower().contains(normalized));
+    }
+
+    private BooleanExpression authorUserIdEq(Long authorUserId) {
+        if (authorUserId == null) {
+            return null;
+        }
+        return post.user.id.eq(authorUserId);
     }
 
     private BooleanExpression latestCursorCondition(LocalDateTime cursorCreatedAt, Long cursorId) {

--- a/src/main/java/com/wilo/server/community/service/CommunityService.java
+++ b/src/main/java/com/wilo/server/community/service/CommunityService.java
@@ -9,6 +9,8 @@ import com.wilo.server.community.dto.CommunityPostDetailResponseDto;
 import com.wilo.server.community.dto.CommunityPostListResponseDto;
 import com.wilo.server.community.dto.CommunityPostSummaryDto;
 import com.wilo.server.community.dto.CommunityPostUpdateRequestDto;
+import com.wilo.server.community.dto.CommunityUserCommentListResponseDto;
+import com.wilo.server.community.dto.CommunityUserCommentSummaryDto;
 import com.wilo.server.community.entity.CommunityCategory;
 import com.wilo.server.community.entity.CommunityComment;
 import com.wilo.server.community.entity.CommunityPost;
@@ -189,6 +191,46 @@ public class CommunityService {
         }
 
         return new CommunityPostListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
+    }
+
+    @Transactional(readOnly = true)
+    public CommunityUserCommentListResponseDto getCommentsByAuthor(
+            Long authorUserId,
+            String cursor,
+            Integer size
+    ) {
+        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
+        Pageable pageable = PageRequest.of(0, safeSize + 1);
+
+        LatestCursor latestCursor = LatestCursor.from(cursor);
+        List<CommunityComment> fetchedComments = communityCommentRepository.findLatestByUserIdCursor(
+                authorUserId,
+                latestCursor.createdAt(),
+                latestCursor.id(),
+                pageable
+        );
+
+        boolean hasNext = fetchedComments.size() > safeSize;
+        List<CommunityComment> pageComments = hasNext ? fetchedComments.subList(0, safeSize) : fetchedComments;
+
+        List<CommunityUserCommentSummaryDto> items = pageComments.stream()
+                .map(comment -> new CommunityUserCommentSummaryDto(
+                        comment.getId(),
+                        comment.getPost().getId(),
+                        comment.getPost().getTitle(),
+                        comment.getContent(),
+                        comment.getCreatedAt(),
+                        calculateDaysAgo(comment.getCreatedAt())
+                ))
+                .toList();
+
+        String nextCursor = null;
+        if (hasNext && !pageComments.isEmpty()) {
+            CommunityComment lastComment = pageComments.get(pageComments.size() - 1);
+            nextCursor = lastComment.getCreatedAt() + "|" + lastComment.getId();
+        }
+
+        return new CommunityUserCommentListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
     }
 
     @Transactional

--- a/src/main/java/com/wilo/server/community/service/CommunityService.java
+++ b/src/main/java/com/wilo/server/community/service/CommunityService.java
@@ -233,6 +233,40 @@ public class CommunityService {
         return new CommunityUserCommentListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
     }
 
+    @Transactional(readOnly = true)
+    public CommunityPostListResponseDto getLikedPostsByUser(
+            Long userId,
+            String cursor,
+            Integer size
+    ) {
+        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
+        Pageable pageable = PageRequest.of(0, safeSize + 1);
+
+        LatestCursor latestCursor = LatestCursor.from(cursor);
+        List<CommunityPostLike> fetchedLikes = communityPostLikeRepository.findLikedPostsByUserIdCursor(
+                userId,
+                latestCursor.createdAt(),
+                latestCursor.id(),
+                pageable
+        );
+
+        boolean hasNext = fetchedLikes.size() > safeSize;
+        List<CommunityPostLike> pageLikes = hasNext ? fetchedLikes.subList(0, safeSize) : fetchedLikes;
+        List<CommunityPost> pagePosts = pageLikes.stream()
+                .map(CommunityPostLike::getPost)
+                .toList();
+
+        List<CommunityPostSummaryDto> items = toSummaryItems(pagePosts);
+
+        String nextCursor = null;
+        if (hasNext && !pageLikes.isEmpty()) {
+            CommunityPostLike lastLike = pageLikes.get(pageLikes.size() - 1);
+            nextCursor = lastLike.getCreatedAt() + "|" + lastLike.getId();
+        }
+
+        return new CommunityPostListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
+    }
+
     @Transactional
     public CommunityPostDetailResponseDto getPostDetail(Long postId) {
         CommunityPost post = getPostOrThrow(postId);

--- a/src/main/java/com/wilo/server/community/service/CommunityService.java
+++ b/src/main/java/com/wilo/server/community/service/CommunityService.java
@@ -147,20 +147,7 @@ public class CommunityService {
         boolean hasNext = fetchedPosts.size() > safeSize;
         List<CommunityPost> pagePosts = hasNext ? fetchedPosts.subList(0, safeSize) : fetchedPosts;
 
-        List<CommunityPostSummaryDto> items = pagePosts.stream()
-                .map(post -> new CommunityPostSummaryDto(
-                        post.getId(),
-                        post.getCategory(),
-                        post.getCategory().getDisplayName(),
-                        post.getTitle(),
-                        createPreview(post.getContent()),
-                        post.getCreatedAt(),
-                        calculateDaysAgo(post.getCreatedAt()),
-                        post.getViewCount(),
-                        post.getLikeCount(),
-                        post.getCommentCount()
-                ))
-                .toList();
+        List<CommunityPostSummaryDto> items = toSummaryItems(pagePosts);
 
         String nextCursor = null;
         if (hasNext && !pagePosts.isEmpty()) {
@@ -169,6 +156,36 @@ public class CommunityService {
                 case LATEST -> LatestCursor.of(lastPost).toCursorValue();
                 case RECOMMENDED -> RecommendedCursor.of(lastPost).toCursorValue();
             };
+        }
+
+        return new CommunityPostListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
+    }
+
+    @Transactional(readOnly = true)
+    public CommunityPostListResponseDto getPostsByAuthor(
+            Long authorUserId,
+            String cursor,
+            Integer size
+    ) {
+        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
+        Pageable pageable = PageRequest.of(0, safeSize + 1);
+
+        LatestCursor latestCursor = LatestCursor.from(cursor);
+        List<CommunityPost> fetchedPosts = communityPostRepository.findLatestPostsByAuthorCursor(
+                authorUserId,
+                latestCursor.createdAt(),
+                latestCursor.id(),
+                pageable
+        );
+
+        boolean hasNext = fetchedPosts.size() > safeSize;
+        List<CommunityPost> pagePosts = hasNext ? fetchedPosts.subList(0, safeSize) : fetchedPosts;
+        List<CommunityPostSummaryDto> items = toSummaryItems(pagePosts);
+
+        String nextCursor = null;
+        if (hasNext && !pagePosts.isEmpty()) {
+            CommunityPost lastPost = pagePosts.get(pagePosts.size() - 1);
+            nextCursor = LatestCursor.of(lastPost).toCursorValue();
         }
 
         return new CommunityPostListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
@@ -321,6 +338,23 @@ public class CommunityService {
     private CommunityPost getPostOrThrow(Long postId) {
         return communityPostRepository.findById(postId)
                 .orElseThrow(() -> ApplicationException.from(CommunityErrorCase.POST_NOT_FOUND));
+    }
+
+    private List<CommunityPostSummaryDto> toSummaryItems(List<CommunityPost> posts) {
+        return posts.stream()
+                .map(post -> new CommunityPostSummaryDto(
+                        post.getId(),
+                        post.getCategory(),
+                        post.getCategory().getDisplayName(),
+                        post.getTitle(),
+                        createPreview(post.getContent()),
+                        post.getCreatedAt(),
+                        calculateDaysAgo(post.getCreatedAt()),
+                        post.getViewCount(),
+                        post.getLikeCount(),
+                        post.getCommentCount()
+                ))
+                .toList();
     }
 
     private long calculateDaysAgo(LocalDateTime createdAt) {

--- a/src/test/java/com/wilo/server/community/CommunityControllerTest.java
+++ b/src/test/java/com/wilo/server/community/CommunityControllerTest.java
@@ -461,6 +461,63 @@ class CommunityControllerTest {
                 .andExpect(jsonPath("$.data.hasNext").value(false));
     }
 
+    @Test
+    void getLikedPostsByUser_latestCursorPagination_success() throws Exception {
+        User postAuthor = saveUser("liked-post-author@example.com", "likedPostAuthor");
+        User liker = saveUser("liked-user@example.com", "likedUser");
+        User other = saveUser("liked-other@example.com", "likedOther");
+
+        CommunityPost post1 = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(postAuthor)
+                        .category(CommunityCategory.TREE_SHADE)
+                        .title("좋아요 글 1")
+                        .content("본문1")
+                        .build()
+        );
+        CommunityPost post2 = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(postAuthor)
+                        .category(CommunityCategory.SUNNY_PLACE)
+                        .title("좋아요 글 2")
+                        .content("본문2")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/likes", post1.getId())
+                        .with(authentication(new JwtAuthentication(liker.getId()))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/likes", post2.getId())
+                        .with(authentication(new JwtAuthentication(liker.getId()))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/likes", post2.getId())
+                        .with(authentication(new JwtAuthentication(other.getId()))))
+                .andExpect(status().isOk());
+
+        MvcResult firstPageResult = mockMvc.perform(get("/api/v1/community/users/{userId}/liked-posts", liker.getId())
+                        .param("size", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.nextCursor").isNotEmpty())
+                .andExpect(jsonPath("$.data.items[0].title").value("좋아요 글 2"))
+                .andReturn();
+        printPrettyResponse(firstPageResult);
+
+        JsonNode firstPageJson = objectMapper.readTree(firstPageResult.getResponse().getContentAsString());
+        String nextCursor = firstPageJson.path("data").path("nextCursor").asText();
+
+        mockMvc.perform(get("/api/v1/community/users/{userId}/liked-posts", liker.getId())
+                        .param("size", "1")
+                        .param("cursor", nextCursor))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.items[0].title").value("좋아요 글 1"))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
     private User saveUser(String email, String nickname) {
         return userRepository.save(
                 User.builder()

--- a/src/test/java/com/wilo/server/community/CommunityControllerTest.java
+++ b/src/test/java/com/wilo/server/community/CommunityControllerTest.java
@@ -343,6 +343,53 @@ class CommunityControllerTest {
                 .andExpect(jsonPath("$.errorCode").value(5004));
     }
 
+    @Test
+    void getPostsByAuthor_latestCursorPagination_success() throws Exception {
+        User author = saveUser("author-list@example.com", "authorList");
+        User other = saveUser("other-list@example.com", "otherList");
+
+        for (int i = 0; i < 3; i++) {
+            communityPostRepository.save(
+                    CommunityPost.builder()
+                            .user(author)
+                            .category(CommunityCategory.TREE_SHADE)
+                            .title("작성자 글 " + i)
+                            .content("작성자 본문 " + i)
+                            .build()
+            );
+        }
+
+        communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(other)
+                        .category(CommunityCategory.SUNNY_PLACE)
+                        .title("다른 사람 글")
+                        .content("다른 사람 본문")
+                        .build()
+        );
+
+        MvcResult firstPageResult = mockMvc.perform(get("/api/v1/community/users/{userId}/posts", author.getId())
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(2))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.nextCursor").isNotEmpty())
+                .andExpect(jsonPath("$.data.items[0].title").value("작성자 글 2"))
+                .andReturn();
+        printPrettyResponse(firstPageResult);
+
+        JsonNode firstPageJson = objectMapper.readTree(firstPageResult.getResponse().getContentAsString());
+        String nextCursor = firstPageJson.path("data").path("nextCursor").asText();
+
+        mockMvc.perform(get("/api/v1/community/users/{userId}/posts", author.getId())
+                        .param("size", "2")
+                        .param("cursor", nextCursor))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.items[0].title").value("작성자 글 0"))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
     private User saveUser(String email, String nickname) {
         return userRepository.save(
                 User.builder()

--- a/src/test/java/com/wilo/server/community/CommunityControllerTest.java
+++ b/src/test/java/com/wilo/server/community/CommunityControllerTest.java
@@ -390,6 +390,77 @@ class CommunityControllerTest {
                 .andExpect(jsonPath("$.data.hasNext").value(false));
     }
 
+    @Test
+    void getCommentsByAuthor_latestCursorPagination_success() throws Exception {
+        User postAuthor = saveUser("post-owner@example.com", "postOwner");
+        User commenter = saveUser("comment-owner@example.com", "commentOwner");
+        User other = saveUser("other-commenter@example.com", "otherCommenter");
+
+        CommunityPost post1 = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(postAuthor)
+                        .category(CommunityCategory.TREE_SHADE)
+                        .title("댓글 대상 글 1")
+                        .content("본문1")
+                        .build()
+        );
+        CommunityPost post2 = communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(postAuthor)
+                        .category(CommunityCategory.SUNNY_PLACE)
+                        .title("댓글 대상 글 2")
+                        .content("본문2")
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post1.getId())
+                        .with(authentication(new JwtAuthentication(commenter.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"내 댓글 1"}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post2.getId())
+                        .with(authentication(new JwtAuthentication(commenter.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"내 댓글 2"}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/community/posts/{postId}/comments", post2.getId())
+                        .with(authentication(new JwtAuthentication(other.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"다른 사람 댓글"}
+                                """))
+                .andExpect(status().isOk());
+
+        MvcResult firstPageResult = mockMvc.perform(get("/api/v1/community/users/{userId}/comments", commenter.getId())
+                        .param("size", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.nextCursor").isNotEmpty())
+                .andExpect(jsonPath("$.data.items[0].postTitle").value("댓글 대상 글 2"))
+                .andExpect(jsonPath("$.data.items[0].content").value("내 댓글 2"))
+                .andReturn();
+        printPrettyResponse(firstPageResult);
+
+        JsonNode firstPageJson = objectMapper.readTree(firstPageResult.getResponse().getContentAsString());
+        String nextCursor = firstPageJson.path("data").path("nextCursor").asText();
+
+        mockMvc.perform(get("/api/v1/community/users/{userId}/comments", commenter.getId())
+                        .param("size", "1")
+                        .param("cursor", nextCursor))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.items[0].postTitle").value("댓글 대상 글 1"))
+                .andExpect(jsonPath("$.data.items[0].content").value("내 댓글 1"))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
     private User saveUser(String email, String nickname) {
         return userRepository.save(
                 User.builder()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #21 

## 📝 작업 내용

> 유저의 커뮤니티 관련 기능을 구현했습니다

- [x] 유저가 작성한 글 조회 api 구현
- [x] 유저가 작성한 댓글 조회 api 구현
- [x] 유저가 공감한 게시글 조회 api 구현

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자별 게시물 조회 기능 추가
  * 사용자별 댓글 조회 기능 추가
  * 사용자가 좋아요한 게시물 조회 기능 추가
  * 모든 새로운 사용자 관련 엔드포인트에 커서 기반 페이지네이션 적용

* **테스트**
  * 새로운 엔드포인트에 대한 페이지네이션 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->