### PR TITLE
[FEAT] 커뮤니티 검색 기록 api 구현

### DIFF
--- a/src/main/java/com/wilo/server/community/controller/CommunityController.java
+++ b/src/main/java/com/wilo/server/community/controller/CommunityController.java
@@ -8,6 +8,7 @@ import com.wilo.server.community.dto.CommunityPostCreateRequestDto;
 import com.wilo.server.community.dto.CommunityPostDetailResponseDto;
 import com.wilo.server.community.dto.CommunityPostListResponseDto;
 import com.wilo.server.community.dto.CommunityPostUpdateRequestDto;
+import com.wilo.server.community.dto.CommunitySearchHistoryListResponseDto;
 import com.wilo.server.community.dto.CommunityUserCommentListResponseDto;
 import com.wilo.server.community.entity.CommunityCategory;
 import com.wilo.server.community.entity.CommunityPostSortType;
@@ -151,7 +152,8 @@ public class CommunityController {
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") Integer size
         ) {
-        return CommonResponse.success(communityService.getPosts(category, sort, keyword, cursor, size));
+        Long userId = extractUserIdIfPresent();
+        return CommonResponse.success(communityService.getPosts(userId, category, sort, keyword, cursor, size));
     }
 
     @GetMapping("/users/{userId}/posts")
@@ -224,6 +226,66 @@ public class CommunityController {
             @RequestParam(defaultValue = "20") Integer size
     ) {
         return CommonResponse.success(communityService.getLikedPostsByUser(userId, cursor, size));
+    }
+
+    @GetMapping("/search-histories")
+    @Operation(
+            summary = "내 검색 기록 조회",
+            description = "로그인 유저의 텍스트 검색 기록을 최신순(lastSearchedAt desc, id desc)으로 커서 페이지네이션 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":1005,\"message\":\"로그인이 필요합니다.\"}")
+                    )
+            )
+    })
+    public CommonResponse<CommunitySearchHistoryListResponseDto> getSearchHistories(
+            @Parameter(description = "커서 값. 포맷: lastSearchedAt|id")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "페이지 크기. 기본값 20, 최대 50")
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        Long userId = extractUserId();
+        return CommonResponse.success(communityService.getSearchHistories(userId, cursor, size));
+    }
+
+    @DeleteMapping("/search-histories/{historyId}")
+    @Operation(summary = "검색 기록 단건 삭제", description = "내 검색 기록 1건을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "타인 기록 삭제 시도",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":5008,\"message\":\"본인의 검색 기록만 삭제할 수 있습니다.\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "검색 기록 없음",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(value = "{\"errorCode\":5007,\"message\":\"검색 기록을 찾을 수 없습니다.\"}")
+                    )
+            )
+    })
+    public CommonResponse<String> deleteSearchHistory(@PathVariable Long historyId) {
+        Long userId = extractUserId();
+        communityService.deleteSearchHistory(userId, historyId);
+        return CommonResponse.success("검색 기록이 삭제되었습니다.");
+    }
+
+    @DeleteMapping("/search-histories")
+    @Operation(summary = "검색 기록 전체 삭제", description = "내 검색 기록 전체를 삭제하고 삭제 건수를 반환합니다.")
+    public CommonResponse<Integer> deleteAllSearchHistories() {
+        Long userId = extractUserId();
+        return CommonResponse.success(communityService.deleteAllSearchHistories(userId));
     }
 
     @GetMapping("/posts/{postId}")
@@ -317,5 +379,24 @@ public class CommunityController {
         }
 
         throw ApplicationException.from(AuthErrorCase.UNAUTHORIZED);
+    }
+
+    private Long extractUserIdIfPresent() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication() != null
+                ? SecurityContextHolder.getContext().getAuthentication().getPrincipal()
+                : null;
+
+        if (principal instanceof Long userId) {
+            return userId;
+        }
+
+        if (principal instanceof String userIdText) {
+            try {
+                return Long.parseLong(userIdText);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/wilo/server/community/controller/CommunityController.java
+++ b/src/main/java/com/wilo/server/community/controller/CommunityController.java
@@ -1,18 +1,19 @@
 package com.wilo.server.community.controller;
 
 import com.wilo.server.auth.error.AuthErrorCase;
-import com.wilo.server.community.dto.CommunityCommentCreateRequestDto;
-import com.wilo.server.community.dto.CommunityCommentDto;
-import com.wilo.server.community.dto.CommunityLikeResponseDto;
-import com.wilo.server.community.dto.CommunityPostCreateRequestDto;
-import com.wilo.server.community.dto.CommunityPostDetailResponseDto;
-import com.wilo.server.community.dto.CommunityPostListResponseDto;
-import com.wilo.server.community.dto.CommunityPostUpdateRequestDto;
-import com.wilo.server.community.dto.CommunitySearchHistoryListResponseDto;
-import com.wilo.server.community.dto.CommunityUserCommentListResponseDto;
-import com.wilo.server.community.entity.CommunityCategory;
-import com.wilo.server.community.entity.CommunityPostSortType;
-import com.wilo.server.community.service.CommunityService;
+import com.wilo.server.community.dto.comment.CommunityCommentCreateRequestDto;
+import com.wilo.server.community.dto.comment.CommunityCommentDto;
+import com.wilo.server.community.dto.post.CommunityLikeResponseDto;
+import com.wilo.server.community.dto.post.CommunityPostCreateRequestDto;
+import com.wilo.server.community.dto.post.CommunityPostDetailResponseDto;
+import com.wilo.server.community.dto.post.CommunityPostListResponseDto;
+import com.wilo.server.community.dto.post.CommunityPostUpdateRequestDto;
+import com.wilo.server.community.dto.search.CommunitySearchHistoryListResponseDto;
+import com.wilo.server.community.dto.comment.CommunityUserCommentListResponseDto;
+import com.wilo.server.community.entity.post.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityPostSortType;
+import com.wilo.server.community.service.community.CommunityService;
+import com.wilo.server.community.service.search.CommunitySearchService;
 import com.wilo.server.global.exception.ApplicationException;
 import com.wilo.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,6 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommunityController {
 
     private final CommunityService communityService;
+    private final CommunitySearchService communitySearchService;
 
     @PostMapping("/posts")
     @Operation(summary = "게시글 작성", description = "카테고리/제목/내용/이미지 URL로 게시글을 생성합니다.")
@@ -153,7 +155,7 @@ public class CommunityController {
             @RequestParam(defaultValue = "20") Integer size
         ) {
         Long userId = extractUserIdIfPresent();
-        return CommonResponse.success(communityService.getPosts(userId, category, sort, keyword, cursor, size));
+        return CommonResponse.success(communitySearchService.getPosts(userId, category, sort, keyword, cursor, size));
     }
 
     @GetMapping("/users/{userId}/posts")
@@ -251,7 +253,7 @@ public class CommunityController {
             @RequestParam(defaultValue = "20") Integer size
     ) {
         Long userId = extractUserId();
-        return CommonResponse.success(communityService.getSearchHistories(userId, cursor, size));
+        return CommonResponse.success(communitySearchService.getSearchHistories(userId, cursor, size));
     }
 
     @DeleteMapping("/search-histories/{historyId}")
@@ -277,7 +279,7 @@ public class CommunityController {
     })
     public CommonResponse<String> deleteSearchHistory(@PathVariable Long historyId) {
         Long userId = extractUserId();
-        communityService.deleteSearchHistory(userId, historyId);
+        communitySearchService.deleteSearchHistory(userId, historyId);
         return CommonResponse.success("검색 기록이 삭제되었습니다.");
     }
 
@@ -285,7 +287,7 @@ public class CommunityController {
     @Operation(summary = "검색 기록 전체 삭제", description = "내 검색 기록 전체를 삭제하고 삭제 건수를 반환합니다.")
     public CommonResponse<Integer> deleteAllSearchHistories() {
         Long userId = extractUserId();
-        return CommonResponse.success(communityService.deleteAllSearchHistories(userId));
+        return CommonResponse.success(communitySearchService.deleteAllSearchHistories(userId));
     }
 
     @GetMapping("/posts/{postId}")

--- a/src/main/java/com/wilo/server/community/dto/CommunitySearchHistoryItemDto.java
+++ b/src/main/java/com/wilo/server/community/dto/CommunitySearchHistoryItemDto.java
@@ -1,0 +1,10 @@
+package com.wilo.server.community.dto;
+
+import java.time.LocalDateTime;
+
+public record CommunitySearchHistoryItemDto(
+        Long id,
+        String keyword,
+        LocalDateTime lastSearchedAt
+) {
+}

--- a/src/main/java/com/wilo/server/community/dto/CommunitySearchHistoryListResponseDto.java
+++ b/src/main/java/com/wilo/server/community/dto/CommunitySearchHistoryListResponseDto.java
@@ -1,0 +1,12 @@
+package com.wilo.server.community.dto;
+
+import java.util.List;
+
+public record CommunitySearchHistoryListResponseDto(
+        List<CommunitySearchHistoryItemDto> items,
+        String cursor,
+        int size,
+        boolean hasNext,
+        String nextCursor
+) {
+}

--- a/src/main/java/com/wilo/server/community/dto/comment/CommunityCommentCreateRequestDto.java
+++ b/src/main/java/com/wilo/server/community/dto/comment/CommunityCommentCreateRequestDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.comment;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/wilo/server/community/dto/comment/CommunityCommentDto.java
+++ b/src/main/java/com/wilo/server/community/dto/comment/CommunityCommentDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.comment;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/com/wilo/server/community/dto/comment/CommunityPostAuthorDto.java
+++ b/src/main/java/com/wilo/server/community/dto/comment/CommunityPostAuthorDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.comment;
 
 import com.wilo.server.user.entity.User;
 

--- a/src/main/java/com/wilo/server/community/dto/comment/CommunityUserCommentListResponseDto.java
+++ b/src/main/java/com/wilo/server/community/dto/comment/CommunityUserCommentListResponseDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.comment;
 
 import java.util.List;
 

--- a/src/main/java/com/wilo/server/community/dto/comment/CommunityUserCommentSummaryDto.java
+++ b/src/main/java/com/wilo/server/community/dto/comment/CommunityUserCommentSummaryDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.comment;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/wilo/server/community/dto/post/CommunityLikeResponseDto.java
+++ b/src/main/java/com/wilo/server/community/dto/post/CommunityLikeResponseDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.post;
 
 public record CommunityLikeResponseDto(
         boolean liked,

--- a/src/main/java/com/wilo/server/community/dto/post/CommunityPostCreateRequestDto.java
+++ b/src/main/java/com/wilo/server/community/dto/post/CommunityPostCreateRequestDto.java
@@ -1,12 +1,12 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.post;
 
-import com.wilo.server.community.entity.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-public record CommunityPostUpdateRequestDto(
+public record CommunityPostCreateRequestDto(
         @NotNull(message = "카테고리는 필수입니다.")
         CommunityCategory category,
 

--- a/src/main/java/com/wilo/server/community/dto/post/CommunityPostDetailResponseDto.java
+++ b/src/main/java/com/wilo/server/community/dto/post/CommunityPostDetailResponseDto.java
@@ -1,6 +1,8 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.post;
 
-import com.wilo.server.community.entity.CommunityCategory;
+import com.wilo.server.community.dto.comment.CommunityCommentDto;
+import com.wilo.server.community.dto.comment.CommunityPostAuthorDto;
+import com.wilo.server.community.entity.post.CommunityCategory;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/src/main/java/com/wilo/server/community/dto/post/CommunityPostListResponseDto.java
+++ b/src/main/java/com/wilo/server/community/dto/post/CommunityPostListResponseDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.post;
 
 import java.util.List;
 

--- a/src/main/java/com/wilo/server/community/dto/post/CommunityPostSummaryDto.java
+++ b/src/main/java/com/wilo/server/community/dto/post/CommunityPostSummaryDto.java
@@ -1,6 +1,6 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.post;
 
-import com.wilo.server.community.entity.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityCategory;
 import java.time.LocalDateTime;
 
 public record CommunityPostSummaryDto(

--- a/src/main/java/com/wilo/server/community/dto/post/CommunityPostUpdateRequestDto.java
+++ b/src/main/java/com/wilo/server/community/dto/post/CommunityPostUpdateRequestDto.java
@@ -1,12 +1,12 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.post;
 
-import com.wilo.server.community.entity.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-public record CommunityPostCreateRequestDto(
+public record CommunityPostUpdateRequestDto(
         @NotNull(message = "카테고리는 필수입니다.")
         CommunityCategory category,
 

--- a/src/main/java/com/wilo/server/community/dto/search/CommunitySearchHistoryItemDto.java
+++ b/src/main/java/com/wilo/server/community/dto/search/CommunitySearchHistoryItemDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.search;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/wilo/server/community/dto/search/CommunitySearchHistoryListResponseDto.java
+++ b/src/main/java/com/wilo/server/community/dto/search/CommunitySearchHistoryListResponseDto.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.dto;
+package com.wilo.server.community.dto.search;
 
 import java.util.List;
 

--- a/src/main/java/com/wilo/server/community/entity/CommunitySearchHistory.java
+++ b/src/main/java/com/wilo/server/community/entity/CommunitySearchHistory.java
@@ -1,0 +1,58 @@
+package com.wilo.server.community.entity;
+
+import com.wilo.server.global.entity.BaseEntity;
+import com.wilo.server.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "community_search_histories",
+        uniqueConstraints = @UniqueConstraint(name = "uk_search_history_user_keyword", columnNames = {"user_id", "keyword"}),
+        indexes = {
+                @Index(name = "idx_search_history_user_last_id", columnList = "user_id, last_searched_at, id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommunitySearchHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 120)
+    private String keyword;
+
+    @Column(nullable = false)
+    private LocalDateTime lastSearchedAt;
+
+    @Builder
+    private CommunitySearchHistory(User user, String keyword, LocalDateTime lastSearchedAt) {
+        this.user = user;
+        this.keyword = keyword;
+        this.lastSearchedAt = lastSearchedAt;
+    }
+
+    public void touch(LocalDateTime searchedAt) {
+        this.lastSearchedAt = searchedAt;
+    }
+}

--- a/src/main/java/com/wilo/server/community/entity/comment/CommunityComment.java
+++ b/src/main/java/com/wilo/server/community/entity/comment/CommunityComment.java
@@ -1,5 +1,6 @@
-package com.wilo.server.community.entity;
+package com.wilo.server.community.entity.comment;
 
+import com.wilo.server.community.entity.post.CommunityPost;
 import com.wilo.server.global.entity.BaseEntity;
 import com.wilo.server.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/wilo/server/community/entity/post/CommunityCategory.java
+++ b/src/main/java/com/wilo/server/community/entity/post/CommunityCategory.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.entity;
+package com.wilo.server.community.entity.post;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/wilo/server/community/entity/post/CommunityPost.java
+++ b/src/main/java/com/wilo/server/community/entity/post/CommunityPost.java
@@ -1,5 +1,6 @@
-package com.wilo.server.community.entity;
+package com.wilo.server.community.entity.post;
 
+import com.wilo.server.community.entity.comment.CommunityComment;
 import com.wilo.server.global.entity.BaseEntity;
 import com.wilo.server.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/wilo/server/community/entity/post/CommunityPostImage.java
+++ b/src/main/java/com/wilo/server/community/entity/post/CommunityPostImage.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.entity;
+package com.wilo.server.community.entity.post;
 
 import com.wilo.server.global.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/wilo/server/community/entity/post/CommunityPostLike.java
+++ b/src/main/java/com/wilo/server/community/entity/post/CommunityPostLike.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.entity;
+package com.wilo.server.community.entity.post;
 
 import com.wilo.server.global.entity.BaseEntity;
 import com.wilo.server.user.entity.User;

--- a/src/main/java/com/wilo/server/community/entity/post/CommunityPostSortType.java
+++ b/src/main/java/com/wilo/server/community/entity/post/CommunityPostSortType.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.entity;
+package com.wilo.server.community.entity.post;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/wilo/server/community/entity/search/CommunitySearchHistory.java
+++ b/src/main/java/com/wilo/server/community/entity/search/CommunitySearchHistory.java
@@ -1,4 +1,4 @@
-package com.wilo.server.community.entity;
+package com.wilo.server.community.entity.search;
 
 import com.wilo.server.global.entity.BaseEntity;
 import com.wilo.server.user.entity.User;

--- a/src/main/java/com/wilo/server/community/error/CommunityErrorCase.java
+++ b/src/main/java/com/wilo/server/community/error/CommunityErrorCase.java
@@ -13,7 +13,9 @@ public enum CommunityErrorCase implements ErrorCase {
     INVALID_PARENT_COMMENT(400, 5003, "해당 게시글에 속한 댓글만 답글 부모로 지정할 수 있습니다."),
     REPLY_DEPTH_NOT_ALLOWED(400, 5004, "답글에는 다시 답글을 작성할 수 없습니다."),
     FORBIDDEN_POST_UPDATE(403, 5005, "본인이 작성한 게시글만 수정할 수 있습니다."),
-    FORBIDDEN_POST_DELETE(403, 5006, "본인이 작성한 게시글만 삭제할 수 있습니다.");
+    FORBIDDEN_POST_DELETE(403, 5006, "본인이 작성한 게시글만 삭제할 수 있습니다."),
+    SEARCH_HISTORY_NOT_FOUND(404, 5007, "검색 기록을 찾을 수 없습니다."),
+    FORBIDDEN_SEARCH_HISTORY_ACCESS(403, 5008, "본인의 검색 기록만 삭제할 수 있습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/community/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/CommunityCommentRepository.java
@@ -1,6 +1,6 @@
 package com.wilo.server.community.repository;
 
-import com.wilo.server.community.entity.CommunityComment;
+import com.wilo.server.community.entity.comment.CommunityComment;
 import com.wilo.server.community.repository.query.CommunityCommentQueryRepository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/wilo/server/community/repository/CommunityPostImageRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/CommunityPostImageRepository.java
@@ -1,6 +1,6 @@
 package com.wilo.server.community.repository;
 
-import com.wilo.server.community.entity.CommunityPostImage;
+import com.wilo.server.community.entity.post.CommunityPostImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/wilo/server/community/repository/CommunityPostLikeRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/CommunityPostLikeRepository.java
@@ -1,6 +1,6 @@
 package com.wilo.server.community.repository;
 
-import com.wilo.server.community.entity.CommunityPostLike;
+import com.wilo.server.community.entity.post.CommunityPostLike;
 import com.wilo.server.community.repository.query.CommunityPostLikeQueryRepository;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/wilo/server/community/repository/CommunityPostRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/CommunityPostRepository.java
@@ -1,6 +1,6 @@
 package com.wilo.server.community.repository;
 
-import com.wilo.server.community.entity.CommunityPost;
+import com.wilo.server.community.entity.post.CommunityPost;
 import com.wilo.server.community.repository.query.CommunityPostQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/wilo/server/community/repository/CommunitySearchHistoryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/CommunitySearchHistoryRepository.java
@@ -1,6 +1,6 @@
 package com.wilo.server.community.repository;
 
-import com.wilo.server.community.entity.CommunitySearchHistory;
+import com.wilo.server.community.entity.search.CommunitySearchHistory;
 import com.wilo.server.community.repository.query.CommunitySearchHistoryQueryRepository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/wilo/server/community/repository/CommunitySearchHistoryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/CommunitySearchHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.wilo.server.community.repository;
+
+import com.wilo.server.community.entity.CommunitySearchHistory;
+import com.wilo.server.community.repository.query.CommunitySearchHistoryQueryRepository;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunitySearchHistoryRepository extends JpaRepository<CommunitySearchHistory, Long>, CommunitySearchHistoryQueryRepository {
+
+    Optional<CommunitySearchHistory> findByUserIdAndKeyword(Long userId, String keyword);
+
+    int deleteByUserId(Long userId);
+}

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityCommentQueryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityCommentQueryRepository.java
@@ -1,6 +1,6 @@
 package com.wilo.server.community.repository.query;
 
-import com.wilo.server.community.entity.CommunityComment;
+import com.wilo.server.community.entity.comment.CommunityComment;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityCommentQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityCommentQueryRepositoryImpl.java
@@ -2,9 +2,9 @@ package com.wilo.server.community.repository.query;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.wilo.server.community.entity.CommunityComment;
-import com.wilo.server.community.entity.QCommunityComment;
-import com.wilo.server.community.entity.QCommunityPost;
+import com.wilo.server.community.entity.comment.CommunityComment;
+import com.wilo.server.community.entity.comment.QCommunityComment;
+import com.wilo.server.community.entity.post.QCommunityPost;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityPostLikeQueryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityPostLikeQueryRepository.java
@@ -1,6 +1,6 @@
 package com.wilo.server.community.repository.query;
 
-import com.wilo.server.community.entity.CommunityPostLike;
+import com.wilo.server.community.entity.post.CommunityPostLike;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityPostLikeQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityPostLikeQueryRepositoryImpl.java
@@ -2,9 +2,9 @@ package com.wilo.server.community.repository.query;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.wilo.server.community.entity.CommunityPostLike;
-import com.wilo.server.community.entity.QCommunityPost;
-import com.wilo.server.community.entity.QCommunityPostLike;
+import com.wilo.server.community.entity.post.CommunityPostLike;
+import com.wilo.server.community.entity.post.QCommunityPost;
+import com.wilo.server.community.entity.post.QCommunityPostLike;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityPostQueryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityPostQueryRepository.java
@@ -1,7 +1,7 @@
 package com.wilo.server.community.repository.query;
 
-import com.wilo.server.community.entity.CommunityCategory;
-import com.wilo.server.community.entity.CommunityPost;
+import com.wilo.server.community.entity.post.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityPost;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/wilo/server/community/repository/query/CommunityPostQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunityPostQueryRepositoryImpl.java
@@ -2,9 +2,9 @@ package com.wilo.server.community.repository.query;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.wilo.server.community.entity.CommunityCategory;
-import com.wilo.server.community.entity.CommunityPost;
-import com.wilo.server.community.entity.QCommunityPost;
+import com.wilo.server.community.entity.post.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityPost;
+import com.wilo.server.community.entity.post.QCommunityPost;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/wilo/server/community/repository/query/CommunitySearchHistoryQueryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunitySearchHistoryQueryRepository.java
@@ -1,6 +1,6 @@
 package com.wilo.server.community.repository.query;
 
-import com.wilo.server.community.entity.CommunitySearchHistory;
+import com.wilo.server.community.entity.search.CommunitySearchHistory;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/wilo/server/community/repository/query/CommunitySearchHistoryQueryRepository.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunitySearchHistoryQueryRepository.java
@@ -1,0 +1,16 @@
+package com.wilo.server.community.repository.query;
+
+import com.wilo.server.community.entity.CommunitySearchHistory;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface CommunitySearchHistoryQueryRepository {
+
+    List<CommunitySearchHistory> findLatestByUserIdCursor(
+            Long userId,
+            LocalDateTime cursorLastSearchedAt,
+            Long cursorId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/wilo/server/community/repository/query/CommunitySearchHistoryQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunitySearchHistoryQueryRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.wilo.server.community.repository.query;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wilo.server.community.entity.CommunitySearchHistory;
+import com.wilo.server.community.entity.QCommunitySearchHistory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunitySearchHistoryQueryRepositoryImpl implements CommunitySearchHistoryQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QCommunitySearchHistory history = QCommunitySearchHistory.communitySearchHistory;
+
+    @Override
+    public List<CommunitySearchHistory> findLatestByUserIdCursor(
+            Long userId,
+            LocalDateTime cursorLastSearchedAt,
+            Long cursorId,
+            Pageable pageable
+    ) {
+        return queryFactory
+                .selectFrom(history)
+                .where(
+                        history.user.id.eq(userId),
+                        cursorCondition(cursorLastSearchedAt, cursorId)
+                )
+                .orderBy(history.lastSearchedAt.desc(), history.id.desc())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private BooleanExpression cursorCondition(LocalDateTime cursorLastSearchedAt, Long cursorId) {
+        if (cursorLastSearchedAt == null || cursorId == null) {
+            return null;
+        }
+
+        return history.lastSearchedAt.lt(cursorLastSearchedAt)
+                .or(history.lastSearchedAt.eq(cursorLastSearchedAt).and(history.id.lt(cursorId)));
+    }
+}

--- a/src/main/java/com/wilo/server/community/repository/query/CommunitySearchHistoryQueryRepositoryImpl.java
+++ b/src/main/java/com/wilo/server/community/repository/query/CommunitySearchHistoryQueryRepositoryImpl.java
@@ -2,8 +2,8 @@ package com.wilo.server.community.repository.query;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.wilo.server.community.entity.CommunitySearchHistory;
-import com.wilo.server.community.entity.QCommunitySearchHistory;
+import com.wilo.server.community.entity.search.CommunitySearchHistory;
+import com.wilo.server.community.entity.search.QCommunitySearchHistory;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/wilo/server/community/service/CommunityService.java
+++ b/src/main/java/com/wilo/server/community/service/CommunityService.java
@@ -9,6 +9,8 @@ import com.wilo.server.community.dto.CommunityPostDetailResponseDto;
 import com.wilo.server.community.dto.CommunityPostListResponseDto;
 import com.wilo.server.community.dto.CommunityPostSummaryDto;
 import com.wilo.server.community.dto.CommunityPostUpdateRequestDto;
+import com.wilo.server.community.dto.CommunitySearchHistoryItemDto;
+import com.wilo.server.community.dto.CommunitySearchHistoryListResponseDto;
 import com.wilo.server.community.dto.CommunityUserCommentListResponseDto;
 import com.wilo.server.community.dto.CommunityUserCommentSummaryDto;
 import com.wilo.server.community.entity.CommunityCategory;
@@ -17,11 +19,13 @@ import com.wilo.server.community.entity.CommunityPost;
 import com.wilo.server.community.entity.CommunityPostImage;
 import com.wilo.server.community.entity.CommunityPostLike;
 import com.wilo.server.community.entity.CommunityPostSortType;
+import com.wilo.server.community.entity.CommunitySearchHistory;
 import com.wilo.server.community.error.CommunityErrorCase;
 import com.wilo.server.community.repository.CommunityCommentRepository;
 import com.wilo.server.community.repository.CommunityPostImageRepository;
 import com.wilo.server.community.repository.CommunityPostLikeRepository;
 import com.wilo.server.community.repository.CommunityPostRepository;
+import com.wilo.server.community.repository.CommunitySearchHistoryRepository;
 import com.wilo.server.global.exception.ApplicationException;
 import com.wilo.server.notification.service.NotificationService;
 import com.wilo.server.user.entity.User;
@@ -51,6 +55,7 @@ public class CommunityService {
     private final CommunityPostImageRepository communityPostImageRepository;
     private final CommunityCommentRepository communityCommentRepository;
     private final CommunityPostLikeRepository communityPostLikeRepository;
+    private final CommunitySearchHistoryRepository communitySearchHistoryRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
 
@@ -112,12 +117,15 @@ public class CommunityService {
 
     @Transactional(readOnly = true)
     public CommunityPostListResponseDto getPosts(
+            Long requesterUserId,
             CommunityCategory category,
             CommunityPostSortType sort,
             String keyword,
             String cursor,
             Integer size
     ) {
+        saveSearchKeywordIfNeeded(requesterUserId, keyword);
+
         int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
         CommunityPostSortType sortType = sort == null ? CommunityPostSortType.RECOMMENDED : sort;
         Pageable pageable = PageRequest.of(0, safeSize + 1);
@@ -161,6 +169,62 @@ public class CommunityService {
         }
 
         return new CommunityPostListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
+    }
+
+    @Transactional(readOnly = true)
+    public CommunitySearchHistoryListResponseDto getSearchHistories(
+            Long userId,
+            String cursor,
+            Integer size
+    ) {
+        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
+        Pageable pageable = PageRequest.of(0, safeSize + 1);
+
+        LatestCursor latestCursor = LatestCursor.from(cursor);
+        List<CommunitySearchHistory> fetchedHistories = communitySearchHistoryRepository.findLatestByUserIdCursor(
+                userId,
+                latestCursor.createdAt(),
+                latestCursor.id(),
+                pageable
+        );
+
+        boolean hasNext = fetchedHistories.size() > safeSize;
+        List<CommunitySearchHistory> pageHistories = hasNext
+                ? fetchedHistories.subList(0, safeSize)
+                : fetchedHistories;
+
+        List<CommunitySearchHistoryItemDto> items = pageHistories.stream()
+                .map(history -> new CommunitySearchHistoryItemDto(
+                        history.getId(),
+                        history.getKeyword(),
+                        history.getLastSearchedAt()
+                ))
+                .toList();
+
+        String nextCursor = null;
+        if (hasNext && !pageHistories.isEmpty()) {
+            CommunitySearchHistory lastHistory = pageHistories.get(pageHistories.size() - 1);
+            nextCursor = lastHistory.getLastSearchedAt() + "|" + lastHistory.getId();
+        }
+
+        return new CommunitySearchHistoryListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
+    }
+
+    @Transactional
+    public void deleteSearchHistory(Long userId, Long historyId) {
+        CommunitySearchHistory history = communitySearchHistoryRepository.findById(historyId)
+                .orElseThrow(() -> ApplicationException.from(CommunityErrorCase.SEARCH_HISTORY_NOT_FOUND));
+
+        if (!history.getUser().getId().equals(userId)) {
+            throw ApplicationException.from(CommunityErrorCase.FORBIDDEN_SEARCH_HISTORY_ACCESS);
+        }
+
+        communitySearchHistoryRepository.delete(history);
+    }
+
+    @Transactional
+    public int deleteAllSearchHistories(Long userId) {
+        return communitySearchHistoryRepository.deleteByUserId(userId);
     }
 
     @Transactional(readOnly = true)
@@ -431,6 +495,30 @@ public class CommunityService {
                         post.getCommentCount()
                 ))
                 .toList();
+    }
+
+    private void saveSearchKeywordIfNeeded(Long userId, String keyword) {
+        if (userId == null || keyword == null || keyword.isBlank()) {
+            return;
+        }
+
+        String normalizedKeyword = keyword.trim();
+        if (normalizedKeyword.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        communitySearchHistoryRepository.findByUserIdAndKeyword(userId, normalizedKeyword)
+                .ifPresentOrElse(
+                        history -> history.touch(now),
+                        () -> communitySearchHistoryRepository.save(
+                                CommunitySearchHistory.builder()
+                                        .user(userRepository.getReferenceById(userId))
+                                        .keyword(normalizedKeyword)
+                                        .lastSearchedAt(now)
+                                        .build()
+                        )
+                );
     }
 
     private long calculateDaysAgo(LocalDateTime createdAt) {

--- a/src/main/java/com/wilo/server/community/service/community/CommunityService.java
+++ b/src/main/java/com/wilo/server/community/service/community/CommunityService.java
@@ -1,31 +1,26 @@
-package com.wilo.server.community.service;
+package com.wilo.server.community.service.community;
 
-import com.wilo.server.community.dto.CommunityCommentCreateRequestDto;
-import com.wilo.server.community.dto.CommunityCommentDto;
-import com.wilo.server.community.dto.CommunityLikeResponseDto;
-import com.wilo.server.community.dto.CommunityPostAuthorDto;
-import com.wilo.server.community.dto.CommunityPostCreateRequestDto;
-import com.wilo.server.community.dto.CommunityPostDetailResponseDto;
-import com.wilo.server.community.dto.CommunityPostListResponseDto;
-import com.wilo.server.community.dto.CommunityPostSummaryDto;
-import com.wilo.server.community.dto.CommunityPostUpdateRequestDto;
-import com.wilo.server.community.dto.CommunitySearchHistoryItemDto;
-import com.wilo.server.community.dto.CommunitySearchHistoryListResponseDto;
-import com.wilo.server.community.dto.CommunityUserCommentListResponseDto;
-import com.wilo.server.community.dto.CommunityUserCommentSummaryDto;
-import com.wilo.server.community.entity.CommunityCategory;
-import com.wilo.server.community.entity.CommunityComment;
-import com.wilo.server.community.entity.CommunityPost;
-import com.wilo.server.community.entity.CommunityPostImage;
-import com.wilo.server.community.entity.CommunityPostLike;
-import com.wilo.server.community.entity.CommunityPostSortType;
-import com.wilo.server.community.entity.CommunitySearchHistory;
+import com.wilo.server.community.dto.comment.CommunityCommentCreateRequestDto;
+import com.wilo.server.community.dto.comment.CommunityCommentDto;
+import com.wilo.server.community.dto.post.CommunityLikeResponseDto;
+import com.wilo.server.community.dto.comment.CommunityPostAuthorDto;
+import com.wilo.server.community.dto.post.CommunityPostCreateRequestDto;
+import com.wilo.server.community.dto.post.CommunityPostDetailResponseDto;
+import com.wilo.server.community.dto.post.CommunityPostListResponseDto;
+import com.wilo.server.community.dto.post.CommunityPostSummaryDto;
+import com.wilo.server.community.dto.post.CommunityPostUpdateRequestDto;
+import com.wilo.server.community.dto.comment.CommunityUserCommentListResponseDto;
+import com.wilo.server.community.dto.comment.CommunityUserCommentSummaryDto;
+import com.wilo.server.community.entity.post.CommunityCategory;
+import com.wilo.server.community.entity.comment.CommunityComment;
+import com.wilo.server.community.entity.post.CommunityPost;
+import com.wilo.server.community.entity.post.CommunityPostImage;
+import com.wilo.server.community.entity.post.CommunityPostLike;
 import com.wilo.server.community.error.CommunityErrorCase;
 import com.wilo.server.community.repository.CommunityCommentRepository;
 import com.wilo.server.community.repository.CommunityPostImageRepository;
 import com.wilo.server.community.repository.CommunityPostLikeRepository;
 import com.wilo.server.community.repository.CommunityPostRepository;
-import com.wilo.server.community.repository.CommunitySearchHistoryRepository;
 import com.wilo.server.global.exception.ApplicationException;
 import com.wilo.server.notification.service.NotificationService;
 import com.wilo.server.user.entity.User;
@@ -55,7 +50,6 @@ public class CommunityService {
     private final CommunityPostImageRepository communityPostImageRepository;
     private final CommunityCommentRepository communityCommentRepository;
     private final CommunityPostLikeRepository communityPostLikeRepository;
-    private final CommunitySearchHistoryRepository communitySearchHistoryRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
 
@@ -113,118 +107,6 @@ public class CommunityService {
         }
 
         communityPostRepository.delete(post);
-    }
-
-    @Transactional(readOnly = true)
-    public CommunityPostListResponseDto getPosts(
-            Long requesterUserId,
-            CommunityCategory category,
-            CommunityPostSortType sort,
-            String keyword,
-            String cursor,
-            Integer size
-    ) {
-        saveSearchKeywordIfNeeded(requesterUserId, keyword);
-
-        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
-        CommunityPostSortType sortType = sort == null ? CommunityPostSortType.RECOMMENDED : sort;
-        Pageable pageable = PageRequest.of(0, safeSize + 1);
-
-        List<CommunityPost> fetchedPosts = switch (sortType) {
-            case LATEST -> {
-                LatestCursor latestCursor = LatestCursor.from(cursor);
-                yield communityPostRepository.findLatestPostsByCursor(
-                        category,
-                        keyword,
-                        latestCursor.createdAt(),
-                        latestCursor.id(),
-                        pageable
-                );
-            }
-            case RECOMMENDED -> {
-                RecommendedCursor recommendedCursor = RecommendedCursor.from(cursor);
-                yield communityPostRepository.findRecommendedPostsByCursor(
-                        category,
-                        keyword,
-                        recommendedCursor.likeCount(),
-                        recommendedCursor.createdAt(),
-                        recommendedCursor.id(),
-                        pageable
-                );
-            }
-        };
-
-        boolean hasNext = fetchedPosts.size() > safeSize;
-        List<CommunityPost> pagePosts = hasNext ? fetchedPosts.subList(0, safeSize) : fetchedPosts;
-
-        List<CommunityPostSummaryDto> items = toSummaryItems(pagePosts);
-
-        String nextCursor = null;
-        if (hasNext && !pagePosts.isEmpty()) {
-            CommunityPost lastPost = pagePosts.get(pagePosts.size() - 1);
-            nextCursor = switch (sortType) {
-                case LATEST -> LatestCursor.of(lastPost).toCursorValue();
-                case RECOMMENDED -> RecommendedCursor.of(lastPost).toCursorValue();
-            };
-        }
-
-        return new CommunityPostListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
-    }
-
-    @Transactional(readOnly = true)
-    public CommunitySearchHistoryListResponseDto getSearchHistories(
-            Long userId,
-            String cursor,
-            Integer size
-    ) {
-        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
-        Pageable pageable = PageRequest.of(0, safeSize + 1);
-
-        LatestCursor latestCursor = LatestCursor.from(cursor);
-        List<CommunitySearchHistory> fetchedHistories = communitySearchHistoryRepository.findLatestByUserIdCursor(
-                userId,
-                latestCursor.createdAt(),
-                latestCursor.id(),
-                pageable
-        );
-
-        boolean hasNext = fetchedHistories.size() > safeSize;
-        List<CommunitySearchHistory> pageHistories = hasNext
-                ? fetchedHistories.subList(0, safeSize)
-                : fetchedHistories;
-
-        List<CommunitySearchHistoryItemDto> items = pageHistories.stream()
-                .map(history -> new CommunitySearchHistoryItemDto(
-                        history.getId(),
-                        history.getKeyword(),
-                        history.getLastSearchedAt()
-                ))
-                .toList();
-
-        String nextCursor = null;
-        if (hasNext && !pageHistories.isEmpty()) {
-            CommunitySearchHistory lastHistory = pageHistories.get(pageHistories.size() - 1);
-            nextCursor = lastHistory.getLastSearchedAt() + "|" + lastHistory.getId();
-        }
-
-        return new CommunitySearchHistoryListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
-    }
-
-    @Transactional
-    public void deleteSearchHistory(Long userId, Long historyId) {
-        CommunitySearchHistory history = communitySearchHistoryRepository.findById(historyId)
-                .orElseThrow(() -> ApplicationException.from(CommunityErrorCase.SEARCH_HISTORY_NOT_FOUND));
-
-        if (!history.getUser().getId().equals(userId)) {
-            throw ApplicationException.from(CommunityErrorCase.FORBIDDEN_SEARCH_HISTORY_ACCESS);
-        }
-
-        communitySearchHistoryRepository.delete(history);
-    }
-
-    @Transactional
-    public int deleteAllSearchHistories(Long userId) {
-        return communitySearchHistoryRepository.deleteByUserId(userId);
     }
 
     @Transactional(readOnly = true)
@@ -497,30 +379,6 @@ public class CommunityService {
                 .toList();
     }
 
-    private void saveSearchKeywordIfNeeded(Long userId, String keyword) {
-        if (userId == null || keyword == null || keyword.isBlank()) {
-            return;
-        }
-
-        String normalizedKeyword = keyword.trim();
-        if (normalizedKeyword.isEmpty()) {
-            return;
-        }
-
-        LocalDateTime now = LocalDateTime.now();
-        communitySearchHistoryRepository.findByUserIdAndKeyword(userId, normalizedKeyword)
-                .ifPresentOrElse(
-                        history -> history.touch(now),
-                        () -> communitySearchHistoryRepository.save(
-                                CommunitySearchHistory.builder()
-                                        .user(userRepository.getReferenceById(userId))
-                                        .keyword(normalizedKeyword)
-                                        .lastSearchedAt(now)
-                                        .build()
-                        )
-                );
-    }
-
     private long calculateDaysAgo(LocalDateTime createdAt) {
         return ChronoUnit.DAYS.between(createdAt.toLocalDate(), LocalDate.now());
     }
@@ -562,34 +420,4 @@ public class CommunityService {
         }
     }
 
-    private record RecommendedCursor(Long likeCount, LocalDateTime createdAt, Long id) {
-        private static RecommendedCursor from(String cursor) {
-            if (cursor == null || cursor.isBlank()) {
-                return new RecommendedCursor(null, null, null);
-            }
-
-            String[] parts = cursor.split("\\|");
-            if (parts.length != 3) {
-                return new RecommendedCursor(null, null, null);
-            }
-
-            try {
-                return new RecommendedCursor(
-                        Long.parseLong(parts[0]),
-                        LocalDateTime.parse(parts[1]),
-                        Long.parseLong(parts[2])
-                );
-            } catch (RuntimeException e) {
-                return new RecommendedCursor(null, null, null);
-            }
-        }
-
-        private static RecommendedCursor of(CommunityPost post) {
-            return new RecommendedCursor(post.getLikeCount(), post.getCreatedAt(), post.getId());
-        }
-
-        private String toCursorValue() {
-            return likeCount + "|" + createdAt + "|" + id;
-        }
-    }
 }

--- a/src/main/java/com/wilo/server/community/service/search/CommunitySearchService.java
+++ b/src/main/java/com/wilo/server/community/service/search/CommunitySearchService.java
@@ -1,0 +1,260 @@
+package com.wilo.server.community.service.search;
+
+import com.wilo.server.community.dto.post.CommunityPostListResponseDto;
+import com.wilo.server.community.dto.post.CommunityPostSummaryDto;
+import com.wilo.server.community.dto.search.CommunitySearchHistoryItemDto;
+import com.wilo.server.community.dto.search.CommunitySearchHistoryListResponseDto;
+import com.wilo.server.community.entity.post.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityPost;
+import com.wilo.server.community.entity.post.CommunityPostSortType;
+import com.wilo.server.community.entity.search.CommunitySearchHistory;
+import com.wilo.server.community.error.CommunityErrorCase;
+import com.wilo.server.community.repository.CommunityPostRepository;
+import com.wilo.server.community.repository.CommunitySearchHistoryRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import com.wilo.server.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommunitySearchService {
+
+    private static final int MAX_PAGE_SIZE = 50;
+    private static final int CONTENT_PREVIEW_LENGTH = 120;
+
+    private final CommunityPostRepository communityPostRepository;
+    private final CommunitySearchHistoryRepository communitySearchHistoryRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CommunityPostListResponseDto getPosts(
+            Long requesterUserId,
+            CommunityCategory category,
+            CommunityPostSortType sort,
+            String keyword,
+            String cursor,
+            Integer size
+    ) {
+        saveSearchKeywordIfNeeded(requesterUserId, keyword);
+
+        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
+        CommunityPostSortType sortType = sort == null ? CommunityPostSortType.RECOMMENDED : sort;
+        Pageable pageable = PageRequest.of(0, safeSize + 1);
+
+        List<CommunityPost> fetchedPosts = switch (sortType) {
+            case LATEST -> {
+                LatestCursor latestCursor = LatestCursor.from(cursor);
+                yield communityPostRepository.findLatestPostsByCursor(
+                        category,
+                        keyword,
+                        latestCursor.createdAt(),
+                        latestCursor.id(),
+                        pageable
+                );
+            }
+            case RECOMMENDED -> {
+                RecommendedCursor recommendedCursor = RecommendedCursor.from(cursor);
+                yield communityPostRepository.findRecommendedPostsByCursor(
+                        category,
+                        keyword,
+                        recommendedCursor.likeCount(),
+                        recommendedCursor.createdAt(),
+                        recommendedCursor.id(),
+                        pageable
+                );
+            }
+        };
+
+        boolean hasNext = fetchedPosts.size() > safeSize;
+        List<CommunityPost> pagePosts = hasNext ? fetchedPosts.subList(0, safeSize) : fetchedPosts;
+
+        List<CommunityPostSummaryDto> items = pagePosts.stream()
+                .map(post -> new CommunityPostSummaryDto(
+                        post.getId(),
+                        post.getCategory(),
+                        post.getCategory().getDisplayName(),
+                        post.getTitle(),
+                        createPreview(post.getContent()),
+                        post.getCreatedAt(),
+                        calculateDaysAgo(post.getCreatedAt()),
+                        post.getViewCount(),
+                        post.getLikeCount(),
+                        post.getCommentCount()
+                ))
+                .toList();
+
+        String nextCursor = null;
+        if (hasNext && !pagePosts.isEmpty()) {
+            CommunityPost lastPost = pagePosts.get(pagePosts.size() - 1);
+            nextCursor = switch (sortType) {
+                case LATEST -> LatestCursor.of(lastPost).toCursorValue();
+                case RECOMMENDED -> RecommendedCursor.of(lastPost).toCursorValue();
+            };
+        }
+
+        return new CommunityPostListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
+    }
+
+    @Transactional(readOnly = true)
+    public CommunitySearchHistoryListResponseDto getSearchHistories(
+            Long userId,
+            String cursor,
+            Integer size
+    ) {
+        int safeSize = size == null || size < 1 ? 20 : Math.min(size, MAX_PAGE_SIZE);
+        Pageable pageable = PageRequest.of(0, safeSize + 1);
+
+        LatestCursor latestCursor = LatestCursor.from(cursor);
+        List<CommunitySearchHistory> fetchedHistories = communitySearchHistoryRepository.findLatestByUserIdCursor(
+                userId,
+                latestCursor.createdAt(),
+                latestCursor.id(),
+                pageable
+        );
+
+        boolean hasNext = fetchedHistories.size() > safeSize;
+        List<CommunitySearchHistory> pageHistories = hasNext
+                ? fetchedHistories.subList(0, safeSize)
+                : fetchedHistories;
+
+        List<CommunitySearchHistoryItemDto> items = pageHistories.stream()
+                .map(history -> new CommunitySearchHistoryItemDto(
+                        history.getId(),
+                        history.getKeyword(),
+                        history.getLastSearchedAt()
+                ))
+                .toList();
+
+        String nextCursor = null;
+        if (hasNext && !pageHistories.isEmpty()) {
+            CommunitySearchHistory lastHistory = pageHistories.get(pageHistories.size() - 1);
+            nextCursor = lastHistory.getLastSearchedAt() + "|" + lastHistory.getId();
+        }
+
+        return new CommunitySearchHistoryListResponseDto(items, cursor, safeSize, hasNext, nextCursor);
+    }
+
+    @Transactional
+    public void deleteSearchHistory(Long userId, Long historyId) {
+        CommunitySearchHistory history = communitySearchHistoryRepository.findById(historyId)
+                .orElseThrow(() -> ApplicationException.from(CommunityErrorCase.SEARCH_HISTORY_NOT_FOUND));
+
+        if (!history.getUser().getId().equals(userId)) {
+            throw ApplicationException.from(CommunityErrorCase.FORBIDDEN_SEARCH_HISTORY_ACCESS);
+        }
+
+        communitySearchHistoryRepository.delete(history);
+    }
+
+    @Transactional
+    public int deleteAllSearchHistories(Long userId) {
+        return communitySearchHistoryRepository.deleteByUserId(userId);
+    }
+
+    private void saveSearchKeywordIfNeeded(Long userId, String keyword) {
+        if (userId == null || keyword == null || keyword.isBlank()) {
+            return;
+        }
+
+        String normalizedKeyword = keyword.trim();
+        if (normalizedKeyword.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        communitySearchHistoryRepository.findByUserIdAndKeyword(userId, normalizedKeyword)
+                .ifPresentOrElse(
+                        history -> {
+                            history.touch(now);
+                            communitySearchHistoryRepository.save(history);
+                        },
+                        () -> communitySearchHistoryRepository.save(
+                                CommunitySearchHistory.builder()
+                                        .user(userRepository.getReferenceById(userId))
+                                        .keyword(normalizedKeyword)
+                                        .lastSearchedAt(now)
+                                        .build()
+                        )
+                );
+    }
+
+    private long calculateDaysAgo(LocalDateTime createdAt) {
+        return ChronoUnit.DAYS.between(createdAt.toLocalDate(), LocalDate.now());
+    }
+
+    private String createPreview(String content) {
+        if (content == null) {
+            return "";
+        }
+        if (content.length() <= CONTENT_PREVIEW_LENGTH) {
+            return content;
+        }
+        return content.substring(0, CONTENT_PREVIEW_LENGTH) + "...";
+    }
+
+    private record LatestCursor(LocalDateTime createdAt, Long id) {
+        private static LatestCursor from(String cursor) {
+            if (cursor == null || cursor.isBlank()) {
+                return new LatestCursor(null, null);
+            }
+
+            String[] parts = cursor.split("\\|");
+            if (parts.length != 2) {
+                return new LatestCursor(null, null);
+            }
+
+            try {
+                return new LatestCursor(LocalDateTime.parse(parts[0]), Long.parseLong(parts[1]));
+            } catch (RuntimeException e) {
+                return new LatestCursor(null, null);
+            }
+        }
+
+        private static LatestCursor of(CommunityPost post) {
+            return new LatestCursor(post.getCreatedAt(), post.getId());
+        }
+
+        private String toCursorValue() {
+            return createdAt + "|" + id;
+        }
+    }
+
+    private record RecommendedCursor(Long likeCount, LocalDateTime createdAt, Long id) {
+        private static RecommendedCursor from(String cursor) {
+            if (cursor == null || cursor.isBlank()) {
+                return new RecommendedCursor(null, null, null);
+            }
+
+            String[] parts = cursor.split("\\|");
+            if (parts.length != 3) {
+                return new RecommendedCursor(null, null, null);
+            }
+
+            try {
+                return new RecommendedCursor(
+                        Long.parseLong(parts[0]),
+                        LocalDateTime.parse(parts[1]),
+                        Long.parseLong(parts[2])
+                );
+            } catch (RuntimeException e) {
+                return new RecommendedCursor(null, null, null);
+            }
+        }
+
+        private static RecommendedCursor of(CommunityPost post) {
+            return new RecommendedCursor(post.getLikeCount(), post.getCreatedAt(), post.getId());
+        }
+
+        private String toCursorValue() {
+            return likeCount + "|" + createdAt + "|" + id;
+        }
+    }
+}

--- a/src/main/java/com/wilo/server/notification/service/NotificationService.java
+++ b/src/main/java/com/wilo/server/notification/service/NotificationService.java
@@ -1,7 +1,7 @@
 package com.wilo.server.notification.service;
 
-import com.wilo.server.community.entity.CommunityComment;
-import com.wilo.server.community.entity.CommunityPost;
+import com.wilo.server.community.entity.comment.CommunityComment;
+import com.wilo.server.community.entity.post.CommunityPost;
 import com.wilo.server.notification.dto.NotificationListResponseDto;
 import com.wilo.server.notification.dto.NotificationSummaryDto;
 import com.wilo.server.notification.entity.NotificationType;

--- a/src/test/java/com/wilo/server/community/CommunityControllerTest.java
+++ b/src/test/java/com/wilo/server/community/CommunityControllerTest.java
@@ -10,8 +10,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wilo.server.community.entity.CommunityCategory;
-import com.wilo.server.community.entity.CommunityPost;
+import com.wilo.server.community.entity.post.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityPost;
 import com.wilo.server.community.repository.CommunityCommentRepository;
 import com.wilo.server.community.repository.CommunityPostImageRepository;
 import com.wilo.server.community.repository.CommunityPostLikeRepository;

--- a/src/test/java/com/wilo/server/community/CommunityControllerTest.java
+++ b/src/test/java/com/wilo/server/community/CommunityControllerTest.java
@@ -16,6 +16,7 @@ import com.wilo.server.community.repository.CommunityCommentRepository;
 import com.wilo.server.community.repository.CommunityPostImageRepository;
 import com.wilo.server.community.repository.CommunityPostLikeRepository;
 import com.wilo.server.community.repository.CommunityPostRepository;
+import com.wilo.server.community.repository.CommunitySearchHistoryRepository;
 import com.wilo.server.global.config.security.jwt.JwtAuthentication;
 import com.wilo.server.user.entity.User;
 import com.wilo.server.user.repository.UserRepository;
@@ -56,11 +57,15 @@ class CommunityControllerTest {
     @Autowired
     private CommunityPostImageRepository communityPostImageRepository;
 
+    @Autowired
+    private CommunitySearchHistoryRepository communitySearchHistoryRepository;
+
     @BeforeEach
     void setUp() {
         communityCommentRepository.deleteAll();
         communityPostLikeRepository.deleteAll();
         communityPostImageRepository.deleteAll();
+        communitySearchHistoryRepository.deleteAll();
         communityPostRepository.deleteAll();
         userRepository.deleteAll();
     }
@@ -516,6 +521,101 @@ class CommunityControllerTest {
                 .andExpect(jsonPath("$.data.items.length()").value(1))
                 .andExpect(jsonPath("$.data.items[0].title").value("좋아요 글 1"))
                 .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    void searchHistory_save_list_delete_success() throws Exception {
+        User user = saveUser("search-user@example.com", "searchUser");
+        communityPostRepository.save(
+                CommunityPost.builder()
+                        .user(user)
+                        .category(CommunityCategory.TREE_SHADE)
+                        .title("검색 대상")
+                        .content("검색용 본문")
+                        .build()
+        );
+
+        mockMvc.perform(get("/api/v1/community/posts")
+                        .with(authentication(new JwtAuthentication(user.getId())))
+                        .param("keyword", "나무"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/community/posts")
+                        .with(authentication(new JwtAuthentication(user.getId())))
+                        .param("keyword", "볕"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/community/posts")
+                        .with(authentication(new JwtAuthentication(user.getId())))
+                        .param("keyword", "나무"))
+                .andExpect(status().isOk());
+
+        MvcResult firstPageResult = mockMvc.perform(get("/api/v1/community/search-histories")
+                        .with(authentication(new JwtAuthentication(user.getId())))
+                        .param("size", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.items[0].keyword").value("나무"))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.nextCursor").isNotEmpty())
+                .andReturn();
+        printPrettyResponse(firstPageResult);
+
+        JsonNode firstPageJson = objectMapper.readTree(firstPageResult.getResponse().getContentAsString());
+        long historyId = firstPageJson.path("data").path("items").get(0).path("id").asLong();
+        String nextCursor = firstPageJson.path("data").path("nextCursor").asText();
+
+        mockMvc.perform(get("/api/v1/community/search-histories")
+                        .with(authentication(new JwtAuthentication(user.getId())))
+                        .param("size", "1")
+                        .param("cursor", nextCursor))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.items[0].keyword").value("볕"))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+
+        mockMvc.perform(delete("/api/v1/community/search-histories/{historyId}", historyId)
+                        .with(authentication(new JwtAuthentication(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("success"));
+
+        mockMvc.perform(get("/api/v1/community/search-histories")
+                        .with(authentication(new JwtAuthentication(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1));
+
+        mockMvc.perform(delete("/api/v1/community/search-histories")
+                        .with(authentication(new JwtAuthentication(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(1));
+
+        mockMvc.perform(get("/api/v1/community/search-histories")
+                        .with(authentication(new JwtAuthentication(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(0));
+    }
+
+    @Test
+    void searchHistory_deleteByOtherUser_forbidden() throws Exception {
+        User user = saveUser("search-owner@example.com", "searchOwner");
+        User other = saveUser("search-other@example.com", "searchOther");
+
+        mockMvc.perform(get("/api/v1/community/posts")
+                        .with(authentication(new JwtAuthentication(user.getId())))
+                        .param("keyword", "삭제권한"))
+                .andExpect(status().isOk());
+
+        MvcResult listResult = mockMvc.perform(get("/api/v1/community/search-histories")
+                        .with(authentication(new JwtAuthentication(user.getId()))))
+                .andExpect(status().isOk())
+                .andReturn();
+        long historyId = objectMapper.readTree(listResult.getResponse().getContentAsString())
+                .path("data").path("items").get(0).path("id").asLong();
+
+        mockMvc.perform(delete("/api/v1/community/search-histories/{historyId}", historyId)
+                        .with(authentication(new JwtAuthentication(other.getId()))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(5008));
     }
 
     private User saveUser(String email, String nickname) {

--- a/src/test/java/com/wilo/server/notification/NotificationControllerTest.java
+++ b/src/test/java/com/wilo/server/notification/NotificationControllerTest.java
@@ -10,8 +10,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wilo.server.community.entity.CommunityCategory;
-import com.wilo.server.community.entity.CommunityPost;
+import com.wilo.server.community.entity.post.CommunityCategory;
+import com.wilo.server.community.entity.post.CommunityPost;
 import com.wilo.server.community.repository.CommunityCommentRepository;
 import com.wilo.server.community.repository.CommunityPostImageRepository;
 import com.wilo.server.community.repository.CommunityPostLikeRepository;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 커뮤니티 검색 기록 관련 api 구현

- 검색 시, 검색 기록이 자동 저장되도록 구현
- 검색 기록 조회 & 삭제 api 구현
- 커뮤니티 폴더 구조 변경
  - 게시글, 댓글, 검색으로 분류해서 저장

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 검색 기록 조회 기능 추가 - 커서 기반 페이지네이션으로 검색 기록 목록 조회 가능
  * 개별 검색 기록 삭제 기능 추가
  * 전체 검색 기록 일괄 삭제 기능 추가
  * 게시물 검색 시 정렬 옵션(최신순/추천순) 및 페이지네이션 지원

* **버그 수정**
  * 검색 기록 접근 권한 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->