### PR TITLE
[FEAT] 봇 메시지 피드백 + 추천 버튼 프리셋 조회 API 구현 

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/config/ChatSuggestionPresetSeeder.java
+++ b/src/main/java/com/wilo/server/chatbot/config/ChatSuggestionPresetSeeder.java
@@ -1,0 +1,52 @@
+package com.wilo.server.chatbot.config;
+
+import com.wilo.server.chatbot.entity.ChatSuggestionPreset;
+import com.wilo.server.chatbot.repository.ChatSuggestionPresetRepository;
+import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Order(2)
+public class ChatSuggestionPresetSeeder implements ApplicationRunner {
+
+    private final ChatbotTypeRepository chatbotTypeRepository;
+    private final ChatSuggestionPresetRepository presetRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+
+        seed( "EUNHAENG", 1, "내 감정을 더 잘 이해하고 싶어");
+        seed( "EUNHAENG", 2, "현재의 문제를 해결할 방법을 알고 싶어");
+        seed( "EUNHAENG", 3, "당장 진정하는 방법이 필요해");
+
+        seed( "BUDDLE", 1, "그냥 편하게 얘기하고 싶어");
+        seed( "BUDDLE", 2, "오늘 있었던 일 들어줄래?");
+        seed( "BUDDLE", 3, "내가 너무 예민한 걸까?");
+
+        seed( "NEUTY", 1, "상황을 정리해서 말해볼게");
+        seed( "NEUTY", 2, "선택지를 정리해줘");
+        seed( "NEUTY", 3, "우선순위를 잡고 싶어");
+    }
+
+    private void seed(String chatbotCode, int order, String text) {
+
+        var type = chatbotTypeRepository.findByCode(chatbotCode)
+                .orElseThrow();
+
+        // 같은 타입+문구가 이미 있으면 스킵
+        boolean exists = presetRepository
+                .findAllByChatbotType_IdAndIsActiveTrueOrderBySortOrderAsc(type.getId())
+                .stream().anyMatch(p -> p.getText().equals(text));
+
+        if (exists) return;
+
+        presetRepository.save(ChatSuggestionPreset.create(type, text, order, true));
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/config/ChatbotTypeSeeder.java
+++ b/src/main/java/com/wilo/server/chatbot/config/ChatbotTypeSeeder.java
@@ -5,12 +5,14 @@ import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Order(1)
 @Transactional
 public class ChatbotTypeSeeder implements ApplicationRunner {
 

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatMessageFeedbackController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatMessageFeedbackController.java
@@ -1,0 +1,52 @@
+package com.wilo.server.chatbot.controller;
+
+import com.wilo.server.chatbot.dto.ChatMessageFeedbackRequest;
+import com.wilo.server.chatbot.dto.ChatMessageFeedbackResponse;
+import com.wilo.server.chatbot.service.ChatMessageFeedbackService;
+import com.wilo.server.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat/messages")
+public class ChatMessageFeedbackController {
+
+    private final ChatMessageFeedbackService chatMessageFeedbackService;
+
+    @PatchMapping("/{messageId}/feedback")
+    @Operation(
+            summary = "메시지 피드백",
+            description = """
+                챗봇(BOT) 메시지에 대해 사용자 피드백을 남깁니다.
+                - LIKE : 도움이 되었어요 👍
+                - DISLIKE : 도움이 안 되었어요 👎
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "피드백 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 피드백 요청 또는 USER 메시지",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "메시지 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatMessageFeedbackResponse> giveFeedback(
+            @Parameter(description = "메시지 ID", example = "55")
+            @Min(value = 1, message = "messageId는 1 이상이어야 합니다.")
+            @PathVariable Long messageId,
+            @Valid @RequestBody ChatMessageFeedbackRequest request
+    ) {
+        return CommonResponse.success(chatMessageFeedbackService.giveFeedback(messageId, request));
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSuggestionPresetController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSuggestionPresetController.java
@@ -1,0 +1,50 @@
+package com.wilo.server.chatbot.controller;
+
+import com.wilo.server.chatbot.dto.SuggestionPresetListResponse;
+import com.wilo.server.chatbot.service.ChatSuggestionPresetService;
+import com.wilo.server.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat/suggestion-presets")
+public class ChatSuggestionPresetController {
+
+    private final ChatSuggestionPresetService chatSuggestionPresetService;
+
+    @GetMapping
+    @Operation(
+            summary = "추천 버튼 프리셋 조회",
+            description = """
+                선택된 챗봇 유형에 맞는 추천 질문 프리셋 목록을 조회합니다.
+                - 채팅 시작 전/입력창 위에 보여주는 고정 프리셋 용도
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "챗봇 유형 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<SuggestionPresetListResponse> getPresets(
+            @Parameter(description = "챗봇 유형 ID", example = "1")
+            @Min(value = 1, message = "chatbotTypeId는 1 이상이어야 합니다.")
+            @RequestParam Long chatbotTypeId
+    ) {
+        return CommonResponse.success(chatSuggestionPresetService.getPresets(chatbotTypeId));
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageFeedbackRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageFeedbackRequest.java
@@ -1,0 +1,11 @@
+package com.wilo.server.chatbot.dto;
+
+import com.wilo.server.chatbot.entity.MessageFeedbackType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ChatMessageFeedbackRequest {
+    @NotNull
+    private MessageFeedbackType type;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageFeedbackResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageFeedbackResponse.java
@@ -1,0 +1,11 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageFeedbackResponse {
+    private Long messageId;
+    private String feedback;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/SuggestionPresetItem.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/SuggestionPresetItem.java
@@ -1,0 +1,12 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SuggestionPresetItem {
+    private Long id;
+    private String text;
+    private int order;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/SuggestionPresetListResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/SuggestionPresetListResponse.java
@@ -1,0 +1,20 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SuggestionPresetListResponse {
+    private Long chatbotTypeId;
+    private List<SuggestionPresetItem> presets;
+
+    public static SuggestionPresetListResponse of(Long chatbotTypeId, List<SuggestionPresetItem> presets) {
+        return SuggestionPresetListResponse.builder()
+                .chatbotTypeId(chatbotTypeId)
+                .presets(presets)
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatMessage.java
@@ -42,6 +42,10 @@ public class ChatMessage extends BaseEntity {
     @Column(name = "choices_json")
     private String choicesJson;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "feedback_type", length = 20)
+    private MessageFeedbackType feedbackType;
+
     private static String requireContent(String content) {
         if (content == null || content.isBlank()) {
             throw new IllegalArgumentException("content는 비어 있을 수 없습니다.");
@@ -69,5 +73,9 @@ public class ChatMessage extends BaseEntity {
         m.safetyStatus = safetyStatus;
         m.choicesJson = choicesJson;
         return m;
+    }
+
+    public void updateFeedback(MessageFeedbackType feedbackType) {
+        this.feedbackType = feedbackType;
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSuggestionPreset.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSuggestionPreset.java
@@ -1,0 +1,42 @@
+package com.wilo.server.chatbot.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chat_suggestion_presets",
+        indexes = {
+                @Index(name = "idx_preset_type_active_order", columnList = "chatbot_type_id,is_active,sort_order")
+        })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatSuggestionPreset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatbot_type_id", nullable = false)
+    private ChatbotType chatbotType;
+
+    @Column(nullable = false, length = 200)
+    private String text;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    public static ChatSuggestionPreset create(ChatbotType type, String text, int sortOrder, boolean active) {
+        ChatSuggestionPreset p = new ChatSuggestionPreset();
+        p.chatbotType = type;
+        p.text = text;
+        p.sortOrder = sortOrder;
+        p.isActive = active;
+        return p;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/entity/MessageFeedbackType.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/MessageFeedbackType.java
@@ -1,0 +1,6 @@
+package com.wilo.server.chatbot.entity;
+
+public enum MessageFeedbackType {
+    LIKE,
+    DISLIKE
+}

--- a/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
+++ b/src/main/java/com/wilo/server/chatbot/exception/ChatbotErrorCase.java
@@ -3,6 +3,7 @@ package com.wilo.server.chatbot.exception;
 import com.wilo.server.global.exception.ErrorCase;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -17,7 +18,9 @@ public enum ChatbotErrorCase implements ErrorCase {
     SESSION_DELETE_INVALID(400,3007, "삭제할 세션이 올바르지 않습니다."),
     TITLE_INVALID(400, 3008, "제목이 정책을 충족하지 않습니다."),
     AI_SERVER_FAILED(502, 3009, "AI 서버 응답에 실패했습니다."),
-    AI_RESPONSE_INVALID(502, 3010, "AI 응답 형식이 올바르지 않습니다.");
+    AI_RESPONSE_INVALID(502, 3010, "AI 응답 형식이 올바르지 않습니다."),
+    MESSAGE_NOT_FOUND(404, 3011, "메시지를 찾을 수 없습니다."),
+    INVALID_MESSAGE_FEEDBACK(400, 3012, "봇 메시지에만 피드백을 남길 수 있습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
@@ -82,4 +83,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         where m.sessionId in :sessionIds
     """)
     int deleteBySessionIds(@Param("sessionIds") Collection<Long> sessionIds);
+
+    Optional<ChatMessage> findById(Long id);
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSuggestionPresetRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSuggestionPresetRepository.java
@@ -1,0 +1,10 @@
+package com.wilo.server.chatbot.repository;
+
+import com.wilo.server.chatbot.entity.ChatSuggestionPreset;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatSuggestionPresetRepository extends JpaRepository<ChatSuggestionPreset, Long> {
+    List<ChatSuggestionPreset> findAllByChatbotType_IdAndIsActiveTrueOrderBySortOrderAsc(Long chatbotTypeId);
+}

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatbotTypeRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatbotTypeRepository.java
@@ -4,9 +4,11 @@ import com.wilo.server.chatbot.entity.ChatbotType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatbotTypeRepository extends JpaRepository<ChatbotType, Long> {
 
     List<ChatbotType> findAllByIsActiveTrueOrderByIdAsc();
     boolean existsByCode(String code);
+    Optional<ChatbotType> findByCode(String code);
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageFeedbackService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageFeedbackService.java
@@ -1,0 +1,38 @@
+package com.wilo.server.chatbot.service;
+
+import com.wilo.server.chatbot.dto.ChatMessageFeedbackRequest;
+import com.wilo.server.chatbot.dto.ChatMessageFeedbackResponse;
+import com.wilo.server.chatbot.entity.ChatMessage;
+import com.wilo.server.chatbot.entity.SenderType;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatMessageRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageFeedbackService {
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public ChatMessageFeedbackResponse giveFeedback(Long messageId, ChatMessageFeedbackRequest request) {
+
+        ChatMessage message = chatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.MESSAGE_NOT_FOUND));
+
+        // BOT 메시지만 피드백 가능
+        if (message.getSenderType() != SenderType.BOT) {
+            throw new ApplicationException(ChatbotErrorCase.INVALID_MESSAGE_FEEDBACK);
+        }
+
+        message.updateFeedback(request.getType());
+
+        return ChatMessageFeedbackResponse.builder()
+                .messageId(message.getId())
+                .feedback(request.getType().name())
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSuggestionPresetService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSuggestionPresetService.java
@@ -1,0 +1,41 @@
+package com.wilo.server.chatbot.service;
+
+import com.wilo.server.chatbot.dto.SuggestionPresetItem;
+import com.wilo.server.chatbot.dto.SuggestionPresetListResponse;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatSuggestionPresetRepository;
+import com.wilo.server.chatbot.repository.ChatbotTypeRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatSuggestionPresetService {
+
+    private final ChatbotTypeRepository chatbotTypeRepository;
+    private final ChatSuggestionPresetRepository presetRepository;
+
+    public SuggestionPresetListResponse getPresets(Long chatbotTypeId) {
+
+        // 타입 존재 검증
+        chatbotTypeRepository.findById(chatbotTypeId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.CHATBOT_TYPE_NOT_FOUND));
+
+        List<SuggestionPresetItem> items = presetRepository
+                .findAllByChatbotType_IdAndIsActiveTrueOrderBySortOrderAsc(chatbotTypeId)
+                .stream()
+                .map(p -> SuggestionPresetItem.builder()
+                        .id(p.getId())
+                        .text(p.getText())
+                        .order(p.getSortOrder())
+                        .build())
+                .toList();
+
+        return SuggestionPresetListResponse.of(chatbotTypeId, items);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #37 

## 📝 작업 내용

챗봇 기능 확장을 위해 메시지 피드백 API와 추천 질문 프리셋 조회 API를 구현했습니다.

**1. 메시지 피드백 API 구현**
- PATCH /api/v1/chat/messages/{messageId}/feedback
- 챗봇(BOT)이 생성한 메시지에 대해 사용자가 피드백을 남길 수 있는 기능을 구현했습니다.

**2. 추천 질문 프리셋 조회 API 구현**
- GET /api/v1/chat/suggestion-presets
- 채팅 시작 시 프론트에서 표시할 추천 질문 프리셋 목록을 조회하는 API를 구현했습니다.


## 🖼️ 스크린샷 (선택)
### 메시지 피드백 성공
<img width="1469" height="945" alt="메시지 피드백 성공" src="https://github.com/user-attachments/assets/ea86b694-d05f-4a0a-ba73-b36066aea848" />


### 추천 질문 프리셋 조회 성공
<img width="1469" height="943" alt="추천프리셋조회성공" src="https://github.com/user-attachments/assets/95c89162-cfe1-409a-a452-f16cf4bb3a28" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 채팅 메시지 피드백 기능 추가 - 사용자가 봇 메시지에 좋아요/싫어요 피드백을 남길 수 있습니다.
  * 채봇별 제안 프리셋 기능 - 채봇 유형별 맞춤 제안 목록이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->