### PR TITLE
[FEAT] 미디어 업로드 + 채팅 이미지 첨부 연동 

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/dto/ChatAttachmentDto.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatAttachmentDto.java
@@ -1,0 +1,12 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatAttachmentDto {
+    private Long mediaId;
+    private String url;
+    private String mediaType;
+}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageAttachmentDto.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageAttachmentDto.java
@@ -8,5 +8,6 @@ import lombok.Getter;
 public class ChatMessageAttachmentDto {
     private Long mediaId;
     private String url;
+    private String thumbnailUrl;
     private String mediaType;
 }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendRequest.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,4 +18,6 @@ public class ChatMessageSendRequest {
     @NotBlank(message = "message는 필수입니다.")
     @Size(max = 4000, message = "message는 4000자 이하입니다.")
     private String message;
+
+    List<Long> mediaIds;
 }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatMessageSendRequest.java
@@ -5,8 +5,6 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import jakarta.validation.constraints.NotBlank;
-
 import java.util.List;
 
 @Getter
@@ -15,7 +13,6 @@ import java.util.List;
 public class ChatMessageSendRequest {
     private MessageType messageType;
 
-    @NotBlank(message = "message는 필수입니다.")
     @Size(max = 4000, message = "message는 4000자 이하입니다.")
     private String message;
 

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatMessageAttachment.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatMessageAttachment.java
@@ -1,0 +1,34 @@
+package com.wilo.server.chatbot.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chat_message_attachments",
+        indexes = {
+                @Index(name = "idx_attachment_message", columnList = "message_id"),
+                @Index(name = "idx_attachment_media", columnList = "media_id")
+        })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "message_id", nullable = false)
+    private Long messageId;
+
+    @Column(name = "media_id", nullable = false)
+    private Long mediaId;
+
+    public static ChatMessageAttachment create(Long messageId, Long mediaId) {
+        ChatMessageAttachment attachment = new ChatMessageAttachment();
+        attachment.messageId = messageId;
+        attachment.mediaId = mediaId;
+        return attachment;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageAttachmentRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageAttachmentRepository.java
@@ -1,0 +1,10 @@
+package com.wilo.server.chatbot.repository;
+
+import com.wilo.server.chatbot.entity.ChatMessageAttachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatMessageAttachmentRepository extends JpaRepository<ChatMessageAttachment, Long> {
+    List<ChatMessageAttachment> findAllByMessageId(Long messageId);
+}

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageAttachmentRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageAttachmentRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface ChatMessageAttachmentRepository extends JpaRepository<ChatMessageAttachment, Long> {
     List<ChatMessageAttachment> findAllByMessageId(Long messageId);
+    void deleteAllByMessageId(Long messageId);
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -4,22 +4,25 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wilo.server.chatbot.client.AiChatResult;
 import com.wilo.server.chatbot.client.dto.AiRoleMessage;
+import com.wilo.server.chatbot.dto.ChatMessageAttachmentDto;
 import com.wilo.server.chatbot.dto.ChatMessageDto;
 import com.wilo.server.chatbot.dto.ChatMessageSendRequest;
 import com.wilo.server.chatbot.entity.*;
 import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatMessageAttachmentRepository;
 import com.wilo.server.chatbot.repository.ChatMessageRepository;
 import com.wilo.server.chatbot.repository.ChatSessionMemoryRepository;
 import com.wilo.server.chatbot.repository.ChatSessionRepository;
 import com.wilo.server.global.exception.ApplicationException;
+import com.wilo.server.media.entity.Media;
+import com.wilo.server.media.exception.MediaErrorCase;
+import com.wilo.server.media.repository.MediaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -29,6 +32,8 @@ public class ChatMessageTxService {
     private final ChatSessionRepository chatSessionRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatSessionMemoryRepository chatSessionMemoryRepository;
+    private final ChatMessageAttachmentRepository attachmentRepository;
+    private final MediaRepository mediaRepository;
     private final ObjectMapper objectMapper;
 
     @Transactional(readOnly = true)
@@ -51,15 +56,48 @@ public class ChatMessageTxService {
     @Transactional
     public ChatMessage saveUserMessage(Long sessionId, ChatMessageSendRequest request) {
 
-        MessageType type = (request.getMessageType() == null) ? MessageType.TEXT : request.getMessageType();
-
-        return chatMessageRepository.save(
-                ChatMessage.createUser(sessionId, type, request.getMessage())
+        ChatMessage message = ChatMessage.createUser(
+                sessionId,
+                request.getMessageType(),
+                resolveContentForStorage(request)
         );
+
+        ChatMessage saved = chatMessageRepository.save(message);
+
+        List<Long> mediaIds = request.getMediaIds();
+        if (mediaIds != null && !mediaIds.isEmpty()) {
+
+            // media 존재 검증
+            List<Media> medias = mediaRepository.findAllById(mediaIds);
+            if (medias.size() != mediaIds.size()) {
+                throw new ApplicationException(MediaErrorCase.MEDIA_NOT_FOUND);
+            }
+
+            // attachment 저장
+            List<ChatMessageAttachment> attachments = mediaIds.stream()
+                    .map(mediaId -> ChatMessageAttachment.create(saved.getId(), mediaId))
+                    .toList();
+
+            attachmentRepository.saveAll(attachments);
+        }
+
+        return saved;
+    }
+
+    private String resolveContentForStorage(ChatMessageSendRequest request) {
+
+        if (request.getMessageType() == MessageType.TEXT) {
+            return request.getMessage();
+        }
+        if (request.getMessageType() == MessageType.IMAGE) return "[IMAGE]";
+        if (request.getMessageType() == MessageType.VOICE) return "[VOICE]";
+
+        return request.getMessage();
     }
 
     @Transactional
     public ChatMessage saveBotMessageWithSessionUpdate(Long sessionId, AiChatResult aiResult) {
+
         ChatSession session = chatSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
 
@@ -86,58 +124,29 @@ public class ChatMessageTxService {
         return savedBot;
     }
 
-    public ChatMessageDto toDto(ChatMessage m) {
-
-        List<String> choices = null;
-
-        if (m.getChoicesJson() != null && !m.getChoicesJson().isBlank()) {
-            try {
-                choices = objectMapper.readValue(m.getChoicesJson(), new TypeReference<List<String>>() {});
-            } catch (Exception e) {
-                log.warn("파싱 실패 id={}", m.getId(), e);
-            }
-        }
-
-        return ChatMessageDto.builder()
-                .messageId(m.getId())
-                .senderType(m.getSenderType())
-                .messageType(m.getMessageType())
-                .content(m.getContent())
-                .createdAt(m.getCreatedAt())
-                .safetyStatus(m.getSafetyStatus())
-                .choices(choices)
-                .attachments(List.of())
-                .build();
-    }
-
     @Transactional(readOnly = true)
-    public String getPersonaCodeWithAuthCheck(
-            Long sessionId,
-            Long userId,
-            String guestId
-    ) {
+    public String getPersonaCodeWithAuthCheck(Long sessionId, Long userId, String guestId) {
+
         ChatSession session = chatSessionRepository
                 .findByIdWithChatbotType(sessionId)
                 .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
 
         boolean isOwner = (userId != null && session.getUserId() != null && session.getUserId().equals(userId))
-                        || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
+                || (userId == null && guestId != null && guestId.equals(session.getGuestId()));
 
         if (!isOwner) {
             throw new ApplicationException(ChatbotErrorCase.SESSION_FORBIDDEN);
         }
-        String code = session.getChatbotType().getCode();
 
-        return ChatbotPersona.from(code).name();
+        String code = session.getChatbotType().getCode();
+        return ChatbotPersona.from(code).name(); // "EUNHAENG"|"BUDDLE"|"NEUTY"
     }
 
     @Transactional(readOnly = true)
     public List<AiRoleMessage> findRecentAiMessages(Long sessionId, int n) {
-        if (n <= 0) {
-            return List.of();
-        }
+        if (n <= 0) return List.of();
+
         List<ChatMessage> recentDesc = chatMessageRepository.findRecentDesc(sessionId, PageRequest.of(0, n));
-        // desc → asc로 바꿔 대화 순서 유지
         return recentDesc.reversed().stream()
                 .map(m -> AiRoleMessage.builder()
                         .role(m.getSenderType() == SenderType.USER ? "user" : "assistant")
@@ -151,5 +160,44 @@ public class ChatMessageTxService {
         return chatSessionMemoryRepository.findById(sessionId)
                 .map(ChatSessionMemory::getSummary)
                 .orElse("");
+    }
+
+    @Transactional(readOnly = true)
+    public ChatMessageDto toDto(ChatMessage m) {
+
+        List<String> choices = null;
+        if (m.getChoicesJson() != null && !m.getChoicesJson().isBlank()) {
+            try {
+                choices = objectMapper.readValue(m.getChoicesJson(), new TypeReference<List<String>>() {});
+            } catch (Exception e) {
+                log.warn("choices 파싱 실패 id={}", m.getId(), e);
+            }
+        }
+
+        List<ChatMessageAttachmentDto> attachments = attachmentRepository.findAllByMessageId(m.getId())
+                .stream()
+                .map(att -> {
+                    Media media = mediaRepository.findById(att.getMediaId())
+                            .orElseThrow(() -> new ApplicationException(MediaErrorCase.MEDIA_NOT_FOUND));
+
+                    return ChatMessageAttachmentDto.builder()
+                            .mediaId(media.getId())
+                            .url(media.getUrl())
+                            .thumbnailUrl(media.getThumbnailUrl()) // 없으면 null OK
+                            .mediaType(media.getMediaType().name())
+                            .build();
+                })
+                .toList();
+
+        return ChatMessageDto.builder()
+                .messageId(m.getId())
+                .senderType(m.getSenderType())
+                .messageType(m.getMessageType())
+                .content(m.getContent())
+                .createdAt(m.getCreatedAt())
+                .safetyStatus(m.getSafetyStatus())
+                .choices(choices)
+                .attachments(attachments)
+                .build();
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -71,9 +71,10 @@ public class ChatMessageTxService {
         List<Long> mediaIds = request.getMediaIds();
         if (mediaIds != null && !mediaIds.isEmpty()) {
 
-            // media 존재 검증
-            List<Media> medias = mediaRepository.findAllById(mediaIds);
-            if (medias.size() != mediaIds.size()) {
+            // media 존재 검증 (중복 검증 포함)
+            List<Long> distinctMediaIds = mediaIds.stream().distinct().toList();
+            List<Media> medias = mediaRepository.findAllById(distinctMediaIds);
+            if (medias.size() != distinctMediaIds.size()){
                 throw new ApplicationException(MediaErrorCase.MEDIA_NOT_FOUND);
             }
 

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -139,7 +139,7 @@ public class ChatMessageTxService {
         }
 
         String code = session.getChatbotType().getCode();
-        return ChatbotPersona.from(code).name(); // "EUNHAENG"|"BUDDLE"|"NEUTY"
+        return ChatbotPersona.from(code).name();
     }
 
     @Transactional(readOnly = true)
@@ -183,7 +183,7 @@ public class ChatMessageTxService {
                     return ChatMessageAttachmentDto.builder()
                             .mediaId(media.getId())
                             .url(media.getUrl())
-                            .thumbnailUrl(media.getThumbnailUrl()) // 없으면 null OK
+                            .thumbnailUrl(media.getThumbnailUrl())
                             .mediaType(media.getMediaType().name())
                             .build();
                 })

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -22,6 +22,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -174,20 +178,29 @@ public class ChatMessageTxService {
             }
         }
 
-        List<ChatMessageAttachmentDto> attachments = attachmentRepository.findAllByMessageId(m.getId())
-                .stream()
-                .map(att -> {
-                    Media media = mediaRepository.findById(att.getMediaId())
-                            .orElseThrow(() -> new ApplicationException(MediaErrorCase.MEDIA_NOT_FOUND));
+        List<ChatMessageAttachment> atts = attachmentRepository.findAllByMessageId(m.getId());
 
-                    return ChatMessageAttachmentDto.builder()
-                            .mediaId(media.getId())
-                            .url(media.getUrl())
-                            .thumbnailUrl(media.getThumbnailUrl())
-                            .mediaType(media.getMediaType().name())
-                            .build();
-                })
-                .toList();
+        List<ChatMessageAttachmentDto> attachments = List.of();
+        if (!atts.isEmpty()) {
+            List<Long> mediaIds = atts.stream().map(ChatMessageAttachment::getMediaId).toList();
+            Map<Long, Media> mediaMap = mediaRepository.findAllById(mediaIds)
+                    .stream()
+                    .collect(Collectors.toMap(Media::getId, Function.identity()));
+            attachments = atts.stream()
+                    .map(att -> {
+                        Media media = mediaMap.get(att.getMediaId());
+                        if (media == null) {
+                            throw new ApplicationException(MediaErrorCase.MEDIA_NOT_FOUND);
+                        }
+                        return ChatMessageAttachmentDto.builder()
+                                .mediaId(media.getId())
+                                .url(media.getUrl())
+                                .thumbnailUrl(media.getThumbnailUrl())
+                                .mediaType(media.getMediaType().name())
+                                .build();
+                    })
+                    .toList();
+        }
 
         return ChatMessageDto.builder()
                 .messageId(m.getId())

--- a/src/main/java/com/wilo/server/media/controller/MediaController.java
+++ b/src/main/java/com/wilo/server/media/controller/MediaController.java
@@ -1,0 +1,57 @@
+package com.wilo.server.media.controller;
+
+import com.wilo.server.global.response.CommonResponse;
+import com.wilo.server.media.dto.MediaUploadResponse;
+import com.wilo.server.media.service.MediaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/media")
+public class MediaController {
+
+    private final MediaService mediaService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "미디어 업로드",
+            description = """
+                채팅에서 사진 첨부 버튼을 통해 이미지/오디오 파일을 업로드합니다.
+
+                sourceType
+                - CHAT
+                - COMMUNITY
+                - PROFILE
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "미디어 업로드 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (파일 또는 sourceType 오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "415", description = "지원하지 않는 미디어 타입",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<MediaUploadResponse> uploadMedia(
+
+            @Parameter(description = "업로드할 파일", required = true)
+            @RequestPart("file") MultipartFile file,
+
+            @Parameter(description = "미디어 사용 목적", example = "CHAT")
+            @RequestParam @NotBlank(message = "sourceType은 필수입니다.")
+            String sourceType
+    ) {
+        return CommonResponse.success(mediaService.upload(file, sourceType));
+    }
+}

--- a/src/main/java/com/wilo/server/media/dto/MediaUploadRequest.java
+++ b/src/main/java/com/wilo/server/media/dto/MediaUploadRequest.java
@@ -1,0 +1,10 @@
+package com.wilo.server.media.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MediaUploadRequest {
+    private String sourceType;
+}

--- a/src/main/java/com/wilo/server/media/dto/MediaUploadResponse.java
+++ b/src/main/java/com/wilo/server/media/dto/MediaUploadResponse.java
@@ -1,0 +1,24 @@
+package com.wilo.server.media.dto;
+
+import com.wilo.server.media.entity.Media;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MediaUploadResponse {
+
+    private Long mediaId;
+    private String url;
+    private String thumbnailUrl;
+    private String mediaType;
+
+    public static MediaUploadResponse from(Media media) {
+        return MediaUploadResponse.builder()
+                .mediaId(media.getId())
+                .url(media.getUrl())
+                .thumbnailUrl(media.getThumbnailUrl())
+                .mediaType(media.getMediaType().name())
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/media/entity/Media.java
+++ b/src/main/java/com/wilo/server/media/entity/Media.java
@@ -16,9 +16,10 @@ public class Media extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 2048)
     private String url;
 
+    @Column(length = 2048)
     private String thumbnailUrl;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/wilo/server/media/entity/Media.java
+++ b/src/main/java/com/wilo/server/media/entity/Media.java
@@ -1,0 +1,40 @@
+package com.wilo.server.media.entity;
+
+import com.wilo.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "media")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Media extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String url;
+
+    private String thumbnailUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MediaType mediaType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MediaSourceType sourceType;
+
+    public static Media create(String url, String thumbnailUrl, MediaType mediaType, MediaSourceType sourceType) {
+        Media media = new Media();
+        media.url = url;
+        media.thumbnailUrl = thumbnailUrl;
+        media.mediaType = mediaType;
+        media.sourceType = sourceType;
+        return media;
+    }
+}

--- a/src/main/java/com/wilo/server/media/entity/MediaSourceType.java
+++ b/src/main/java/com/wilo/server/media/entity/MediaSourceType.java
@@ -1,0 +1,7 @@
+package com.wilo.server.media.entity;
+
+public enum MediaSourceType {
+    CHAT,
+    COMMUNITY,
+    PROFILE
+}

--- a/src/main/java/com/wilo/server/media/entity/MediaType.java
+++ b/src/main/java/com/wilo/server/media/entity/MediaType.java
@@ -1,0 +1,6 @@
+package com.wilo.server.media.entity;
+
+public enum MediaType {
+    IMAGE,
+    AUDIO
+}

--- a/src/main/java/com/wilo/server/media/exception/MediaErrorCase.java
+++ b/src/main/java/com/wilo/server/media/exception/MediaErrorCase.java
@@ -1,0 +1,19 @@
+package com.wilo.server.media.exception;
+
+import com.wilo.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MediaErrorCase implements ErrorCase {
+
+    INVALID_MEDIA_FILE(400, 3403, "미디어 파일이 올바르지 않습니다."),
+    UNSUPPORTED_MEDIA_TYPE(400, 3404, "지원하지 않는 미디어 타입입니다."),
+    INVALID_SOURCE_TYPE(400, 3405, "sourceType 값이 올바르지 않습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String message;
+}

--- a/src/main/java/com/wilo/server/media/exception/MediaErrorCase.java
+++ b/src/main/java/com/wilo/server/media/exception/MediaErrorCase.java
@@ -11,7 +11,8 @@ public enum MediaErrorCase implements ErrorCase {
 
     INVALID_MEDIA_FILE(400, 3403, "미디어 파일이 올바르지 않습니다."),
     UNSUPPORTED_MEDIA_TYPE(400, 3404, "지원하지 않는 미디어 타입입니다."),
-    INVALID_SOURCE_TYPE(400, 3405, "sourceType 값이 올바르지 않습니다.");
+    INVALID_SOURCE_TYPE(400, 3405, "sourceType 값이 올바르지 않습니다."),
+    MEDIA_NOT_FOUND(404, 3406, "미디어를 찾을 수 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/media/repository/MediaRepository.java
+++ b/src/main/java/com/wilo/server/media/repository/MediaRepository.java
@@ -1,0 +1,7 @@
+package com.wilo.server.media.repository;
+
+import com.wilo.server.media.entity.Media;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MediaRepository extends JpaRepository<Media, Long> {
+}

--- a/src/main/java/com/wilo/server/media/service/MediaService.java
+++ b/src/main/java/com/wilo/server/media/service/MediaService.java
@@ -1,0 +1,70 @@
+package com.wilo.server.media.service;
+
+import com.wilo.server.files.service.FileService;
+import com.wilo.server.global.exception.ApplicationException;
+import com.wilo.server.media.dto.MediaUploadResponse;
+import com.wilo.server.media.entity.Media;
+import com.wilo.server.media.entity.MediaSourceType;
+import com.wilo.server.media.entity.MediaType;
+import com.wilo.server.media.exception.MediaErrorCase;
+import com.wilo.server.media.repository.MediaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MediaService {
+
+    private final FileService fileService;
+    private final MediaRepository mediaRepository;
+
+    public MediaUploadResponse upload(MultipartFile file, String sourceType) {
+
+        if (file == null || file.isEmpty()) {
+            throw new ApplicationException(MediaErrorCase.INVALID_MEDIA_FILE);
+        }
+
+        String url = fileService.uploadFileToS3(file);
+
+        MediaType mediaType = resolveMediaType(file.getContentType());
+
+        MediaSourceType source;
+
+        try {
+            source = MediaSourceType.valueOf(sourceType);
+        } catch (IllegalArgumentException e) {
+            throw new ApplicationException(MediaErrorCase.INVALID_SOURCE_TYPE);
+        }
+
+        Media media = Media.create(
+                url,
+                null,
+                mediaType,
+                source
+        );
+
+        mediaRepository.save(media);
+
+        return MediaUploadResponse.from(media);
+    }
+
+    private MediaType resolveMediaType(String contentType) {
+
+        if (contentType == null) {
+            throw new ApplicationException(MediaErrorCase.INVALID_MEDIA_FILE);
+        }
+
+        if (contentType.startsWith("image")) {
+            return MediaType.IMAGE;
+        }
+
+        if (contentType.startsWith("audio")) {
+            return MediaType.AUDIO;
+        }
+
+        throw new ApplicationException(MediaErrorCase.UNSUPPORTED_MEDIA_TYPE);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #42 

## 📝 작업 내용
채팅에서 이미지(및 오디오) 업로드 → mediaId 기반 첨부 → 메시지 전송 시 attachments로 응답되는 구조를 백엔드에서 구현

**1. 미디어 업로드 API 구현 (POST /api/v1/media)**
- multipart/form-data로 파일 업로드를 지원합니다.
- 업로드 성공 시 mediaId와 url, mediaType을 반환합니다.

**2. 채팅 메시지 전송 API 확장 (POST /api/v1/chat/sessions/{sessionId}/messages)**
- 기존 TEXT 채팅은 그대로 유지
- IMAGE 메시지 전송 시 mediaIds를 함께 보내면, USER 메시지 저장 시 ChatMessageAttachment로 연결 저장하여 미디어 목록이 포함되어 추출 


### ✅ 프론트 연동 사용 흐름 

**Step 1) 미디어 업로드 API를 동안 mediaid 획득**

```
Response 예시

{
  "message": "success",
  "data": {
    "mediaId": 2,
    "url": "https://...s3.../image/2026/03/05/uuid.png",
    "thumbnailUrl": null,
    "mediaType": "IMAGE"
  }
}
```
프론트에서는 업로드 성공 시 mediaId를 가지고, 다음 Step 2에서 messages API에 넣어주면 됩니다.

**Step 2) 메시지 전송 (IMAGE + mediaIds)**
- POST /api/v1/chat/sessions/{sessionId}/messages

```
Request 예시 (이미지 전송)

{
  "messageType": "IMAGE",
  "message": "",
  "mediaIds": [2]
}
```

messageType=IMAGE일 때는 message가 의미가 없으므로 빈 문자열/누락 둘 다 가능 (렌더링은 attachments 기반)

```
Response 예시

{
  "message": "success",
  "data": {
    "sessionId": 6,
    "userMessage": {
      "messageId": 10,
      "senderType": "USER",
      "messageType": "IMAGE",
      "content": "[IMAGE]",
      "attachments": [
        {
          "mediaId": 2,
          "url": "https://...png",
          "mediaType": "IMAGE"
        }
      ]
    },
    "botMessage": {
      "messageId": 11,
      "senderType": "BOT",
      "messageType": "TEXT",
      "content": "이미지를 확인했어. 어떤 부분이 가장 신경 쓰여?",
      "choices": ["...", "...", "..."],
      "safetyStatus": "SAFE",
      "attachments": []
    }
  }
}
```

**Step 3) 프론트 렌더링 규칙** 
- messageType=TEXT → 기존대로 content 렌더
- messageType=IMAGE → attachments[]의 url을 이미지로 렌더 (content는 placeholder)

### 🧩 API 정리
**미디어 업로드**
- POST /api/v1/media
- form-data: file, sourceType

**채팅 메시지 전송(확장)**
- POST /api/v1/chat/sessions/{sessionId}/messages
- TEXT: messageType=TEXT, message 필수
- IMAGE: messageType=IMAGE, mediaIds 필수(1개 이상 권장)

## 🖼️ 스크린샷 (선택)
### 이미지 업로드 성공
<img width="1467" height="851" alt="이미지업로드성공" src="https://github.com/user-attachments/assets/348c25d1-14b1-4301-a855-fba1bf741e74" />

### 채팅 이미지 첨부 연동 성공
<img width="1497" height="795" alt="이미지채팅성공" src="https://github.com/user-attachments/assets/c6f3288e-14ac-4f8b-9465-e8f925c85509" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 이미지·오디오 업로드 기능 추가(썸네일 포함) 및 업로드용 REST API 제공(소스 타입 지정).
  * 채팅에서 미디어 첨부 지원 — 메시지에 미디어 ID 리스트 전송 가능, 첨부 미디어의 URL·타입·썸네일이 메시지에 포함되어 표시됨.
  * 미디어 저장·조회·삭제를 위한 백엔드 저장소 및 에러 응답(미디어 관련 상태) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->