### PR TITLE
[REFACTOR] 대화 보관함(세션 목록) API의 커서 기반 페이지네이션 구조 개선

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatSessionController.java
@@ -54,26 +54,30 @@ public class ChatSessionController {
     @Operation(
             summary = "대화 보관함(세션 목록) 조회",
             description = """
-                    대화 세션 목록을 커서 기반으로 조회합니다.
-                    
-                    정렬 기준:
-                    - lastMessageAt DESC
-                    - id DESC
-                    
-                    페이징 방식:
-                    - 복합 커서(lastMessageAt + id) 기반 Keyset Pagination
-                    
-                    기본값:
-                    - status = ACTIVE
-                    - size = 20
-                    
-                    제한:
-                    - size 최대 50
-                    
-                    인증 정책:
-                    - 로그인 사용자 → userId 기반 조회
-                    - 비로그인 사용자 → X-Guest-Id 헤더 필요
-                    """
+                대화 세션 목록을 커서 기반으로 조회합니다.
+
+                정렬 기준:
+                - activityAt DESC
+                - id DESC
+
+                activityAt 정의:
+                - lastMessageAt 이 존재하면 lastMessageAt
+                - 없으면 createdAt
+
+                페이징 방식:
+                - 복합 커서(activityAt + id) 기반 Keyset Pagination
+
+                기본값:
+                - status = ACTIVE
+                - size = 20
+
+                제한:
+                - size 최대 50
+
+                인증 정책:
+                - 로그인 사용자 → userId 기반 조회
+                - 비로그인 사용자 → X-Guest-Id 헤더 필요
+                """
     )
     @ApiResponses(value = {
 
@@ -89,37 +93,57 @@ public class ChatSessionController {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<ChatSessionListResponse> getSessions(
-            @Parameter(description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+
+            @Parameter(
+                    description = "비로그인 사용자 식별자(UUID). 비로그인 요청 시 필수",
+                    example = "550e8400-e29b-41d4-a716-446655440000"
+            )
             @RequestHeader(value = "X-Guest-Id", required = false)
             String guestId,
 
-            @Parameter(description = "기본 ACTIVE, 옵션: ACTIVE 또는 ARCHIVED", example = "ACTIVE")
+            @Parameter(
+                    description = "기본 ACTIVE, 옵션: ACTIVE 또는 ARCHIVED",
+                    example = "ACTIVE"
+            )
             @RequestParam(required = false)
             @Pattern(regexp = "ACTIVE|ARCHIVED", message = "유효하지 않은 상태값입니다.")
             String status,
 
-            @Parameter(description = "이전 페이지 마지막 세션의 lastMessageAt 값", example = "2026-02-19T10:40:00")
+            @Parameter(
+                    description = "이전 페이지 마지막 세션의 activityAt 값 (activityAt = lastMessageAt 없으면 createdAt)",
+                    example = "2026-02-19T10:40:00"
+            )
             @RequestParam(required = false)
-            LocalDateTime cursorLastMessageAt,
+            LocalDateTime cursorActivityAt,
 
-            @Parameter(description = "이전 페이지 마지막 세션의 sessionId 값", example = "101")
+            @Parameter(
+                    description = "이전 페이지 마지막 세션의 sessionId 값",
+                    example = "101"
+            )
             @RequestParam(required = false)
             Long cursorId,
 
-            @Parameter(description = "페이지 크기 (기본 20, 최대 50)", example = "20")
+            @Parameter(
+                    description = "페이지 크기 (기본 20, 최대 50)",
+                    example = "20"
+            )
             @RequestParam(required = false)
             @Min(value = 1, message = "size는 1 이상이어야 합니다.")
             @Max(value = 50, message = "size는 50 이하여야 합니다.")
             Integer size
     ) {
+
         ChatSessionListRequest request =
                 new ChatSessionListRequest(
                         status,
-                        cursorLastMessageAt,
+                        cursorActivityAt,
                         cursorId,
                         size
                 );
-        return CommonResponse.success(chatSessionService.getSessions(guestId, request));
+
+        return CommonResponse.success(
+                chatSessionService.getSessions(guestId, request)
+        );
     }
 
     @PatchMapping("/{sessionId}")

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListItem.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListItem.java
@@ -12,5 +12,6 @@ public class ChatSessionListItem {
     private ChatbotTypeDto chatbotType;
     private String status;
     private LocalDateTime lastMessageAt;
+    private LocalDateTime activityAt;
     private String preview;
 }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListRequest.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListRequest.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 public record ChatSessionListRequest(
         String status,
-        LocalDateTime cursorLastMessageAt,
+        LocalDateTime cursorActivityAt,
         Long cursorId,
         Integer size
 ) {}

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatSessionListResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Builder
 public class ChatSessionListResponse {
     private List<ChatSessionListItem> sessions;
-    private LocalDateTime nextCursorLastMessageAt;
+    private LocalDateTime nextCursorActivityAt;
     private Long nextCursorId;
     private boolean hasNext;
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -9,7 +9,12 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "chat_sessions")
+@Table(
+        name = "chat_sessions",
+        indexes = {
+                @Index(name = "idx_chat_sessions_created_at", columnList = "created_at")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatSession {
 
@@ -17,11 +22,9 @@ public class ChatSession {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 로그인 사용자면 user_id 세팅
     @Column(name = "user_id")
     private Long userId;
 
-    // 게스트면 guest_id 세팅
     @Column(name = "guest_id", length = 100)
     private String guestId;
 
@@ -44,7 +47,9 @@ public class ChatSession {
 
     @PrePersist
     public void prePersist() {
-        this.createdAt = LocalDateTime.now();
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
     }
 
     public static ChatSession createForUser(Long userId, ChatbotType chatbotType) {

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -77,7 +77,7 @@ public class ChatSession extends BaseEntity {
         this.status = ChatSessionStatus.ARCHIVED;
     }
 
-    public void restore() {
+    public void unarchive() {
         this.status = ChatSessionStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -1,5 +1,6 @@
 package com.wilo.server.chatbot.entity;
 
+import com.wilo.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import java.time.LocalDateTime;
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatSession {
+public class ChatSession extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,16 +42,6 @@ public class ChatSession {
 
     @Column(name = "last_message_at")
     private LocalDateTime lastMessageAt;
-
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @PrePersist
-    public void prePersist() {
-        if (this.createdAt == null) {
-            this.createdAt = LocalDateTime.now();
-        }
-    }
 
     public static ChatSession createForUser(Long userId, ChatbotType chatbotType) {
         ChatSession session = new ChatSession();

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatSession.java
@@ -39,6 +39,14 @@ public class ChatSession {
     @Column(name = "last_message_at")
     private LocalDateTime lastMessageAt;
 
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
     public static ChatSession createForUser(Long userId, ChatbotType chatbotType) {
         ChatSession session = new ChatSession();
         session.userId = userId;

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+
     @Query("""
         select cs
         from ChatSession cs
@@ -26,18 +27,22 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
             )
           and cs.status = :status
           and (
-                :cursorLastMessageAt is null
-                or cs.lastMessageAt < :cursorLastMessageAt
-                or (cs.lastMessageAt = :cursorLastMessageAt and cs.id < :cursorId)
-                or (cs.lastMessageAt is null and :cursorLastMessageAt is null and cs.id < :cursorId)
+                :cursorActivityAt is null
+                or (
+                    coalesce(cs.lastMessageAt, cs.createdAt) < :cursorActivityAt
+                    or (
+                        coalesce(cs.lastMessageAt, cs.createdAt) = :cursorActivityAt
+                        and cs.id < :cursorId
+                    )
+                )
           )
-        order by cs.lastMessageAt desc nulls last, cs.id desc
+        order by coalesce(cs.lastMessageAt, cs.createdAt) desc, cs.id desc
     """)
     List<ChatSession> findSessions(
             @Param("userId") Long userId,
             @Param("guestId") String guestId,
             @Param("status") ChatSessionStatus status,
-            @Param("cursorLastMessageAt") LocalDateTime cursorLastMessageAt,
+            @Param("cursorActivityAt") LocalDateTime cursorActivityAt,
             @Param("cursorId") Long cursorId,
             Pageable pageable
     );

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -82,14 +82,15 @@ public class ChatSessionService {
             throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
         }
 
-        LocalDateTime cursorLastMessageAt = request.cursorLastMessageAt();
+        LocalDateTime cursorActivityAt = request.cursorActivityAt();
         Long cursorId = request.cursorId();
 
         if (cursorId != null && cursorId <= 0) {
             throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
         }
 
-        if ((cursorLastMessageAt == null) != (cursorId == null)) {
+        // cursor는 둘 다 있거나 둘 다 없어야 함
+        if ((cursorActivityAt == null) != (cursorId == null)) {
             throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
         }
 
@@ -99,12 +100,13 @@ public class ChatSessionService {
                 userId,
                 guestId,
                 status,
-                cursorLastMessageAt,
+                cursorActivityAt,
                 cursorId,
                 pageable
         );
 
         boolean hasNext = sessions.size() > size;
+
         if (hasNext) {
             sessions = sessions.subList(0, size);
         }
@@ -113,18 +115,21 @@ public class ChatSessionService {
                 .map(this::toItem)
                 .toList();
 
-        LocalDateTime nextCursorLastMessageAt = null;
+        LocalDateTime nextCursorActivityAt = null;
         Long nextCursorId = null;
 
         if (hasNext && !sessions.isEmpty()) {
             ChatSession last = sessions.get(sessions.size() - 1);
-            nextCursorLastMessageAt = last.getLastMessageAt();
+
+            LocalDateTime activityAt = last.getLastMessageAt() != null ? last.getLastMessageAt() : last.getCreatedAt();
+
+            nextCursorActivityAt = activityAt;
             nextCursorId = last.getId();
         }
 
         return ChatSessionListResponse.builder()
                 .sessions(items)
-                .nextCursorLastMessageAt(nextCursorLastMessageAt)
+                .nextCursorActivityAt(nextCursorActivityAt)
                 .nextCursorId(nextCursorId)
                 .hasNext(hasNext)
                 .build();

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -255,6 +255,9 @@ public class ChatSessionService {
     private ChatSessionListItem toItem(ChatSession session) {
         String preview = session.getTitle();
 
+        LocalDateTime activityAt =
+                session.getLastMessageAt() != null ? session.getLastMessageAt() : session.getCreatedAt();
+
         return ChatSessionListItem.builder()
                 .sessionId(session.getId())
                 .title(session.getTitle())
@@ -264,6 +267,7 @@ public class ChatSessionService {
                         .build())
                 .status(session.getStatus().name())
                 .lastMessageAt(session.getLastMessageAt())
+                .activityAt(activityAt)
                 .preview(preview)
                 .build();
     }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatSessionService.java
@@ -244,7 +244,7 @@ public class ChatSessionService {
             throw new ApplicationException(ChatbotErrorCase.INVALID_PARAMETER);
         }
 
-        session.restore();
+        session.unarchive();
 
         return ChatSessionRestoreResponse.builder()
                 .sessionId(session.getId())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #50 

## 📝 작업 내용
문제: 기존 정렬 방식은 lastMessageAt DESC, id DESC 였지만 LastMessageAt은 메시지가 없는 세션의 경우 null 값이 될 수 있어 
- 세션 생성 후 메시지를 보내지 않고 이탈한 경우
- 테스트 환경에서 세션만 생성된 경우
- 프론트에서 첫 메시지 입력 전 화면 이탈

같은 경우 lastMessageAt 기반 커서 pagination에서 null 커서 처리 문제가 발생 가능
때문에 정렬 기준을 activityAt 기반으로 변경했습니다. (메시지가 존재하면 → lastMessageAt , 메시지가 없으면 → createdAt)


## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> DB 마이그레이션 필요

```
ALTER TABLE chat_sessions
ADD COLUMN created_at DATETIME NULL,
ADD COLUMN updated_at DATETIME NULL,
ADD COLUMN deleted_at DATETIME NULL;

UPDATE chat_sessions
SET created_at = NOW()
WHERE created_at IS NULL;

UPDATE chat_sessions
SET updated_at = NOW()
WHERE updated_at IS NULL;

ALTER TABLE chat_sessions
MODIFY created_at DATETIME NOT NULL,
MODIFY updated_at DATETIME NOT NULL;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 세션 목록 정렬이 최신 활동(최신 메시지 또는 생성 시각)을 기준으로 변경되어 보다 직관적인 정렬을 제공합니다.
  * 메시지가 없는 세션도 활동 시간으로 처리되어 목록에 정확히 반영됩니다.
  * 페이지네이션 커서가 활동 시간을 기준으로 업데이트되어 다음/이전 페이지 이동이 더욱 정확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->