### PR TITLE
[REFACTOR] S3 이미지 업로드 API Swagger 지원 및 PublicRead 권한 설정 + 챗봇 타입에 배경색,테두리색 관련 필드 추가 

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/config/ChatbotTypeSeeder.java
+++ b/src/main/java/com/wilo/server/chatbot/config/ChatbotTypeSeeder.java
@@ -22,17 +22,26 @@ public class ChatbotTypeSeeder implements ApplicationRunner {
     public void run(ApplicationArguments args) {
 
         seed("EUNHAENG", "편안한 친구", "지금의 상태를 먼저 읽어주는 존재",
-                "https://cdn.wilo.com/chatbot/eunhaeng.png");
+                "https://cdn.wilo.com/chatbot/eunhaeng.png","#FCEBB2",
+                "#F4C008");
 
         seed("BUDDLE", "따뜻한 조력자", "선택을 대신하지 않고 정리해주는 존재",
-                "https://cdn.wilo.com/chatbot/buddle.png");
+                "https://cdn.wilo.com/chatbot/buddle.png","#B0E7EE",
+                "#00B3C9");
 
         seed("NEUTY", "안전한 동반자", "혼자가 되지 않도록 곁을 지키는 존재",
-                "https://cdn.wilo.com/chatbot/neuty.png");
+                "https://cdn.wilo.com/chatbot/neuty.png","#F35A38",
+                "#FBCCC1");
     }
 
-    private void seed(String code, String name, String desc, String imageUrl) {
-
+    private void seed(
+            String code,
+            String name,
+            String desc,
+            String imageUrl,
+            String backgroundColor,
+            String borderColor
+    ) {
         if (chatbotTypeRepository.existsByCode(code)) {
             return;
         }
@@ -44,7 +53,10 @@ public class ChatbotTypeSeeder implements ApplicationRunner {
                             name,
                             desc,
                             imageUrl,
-                            true)
+                            true,
+                            backgroundColor,
+                            borderColor
+                    )
             );
         } catch (DataIntegrityViolationException ignored) {
         }

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeItem.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatbotTypeItem.java
@@ -14,6 +14,8 @@ public class ChatbotTypeItem {
     private String description;
     private String imageUrl;
     private boolean active;
+    private String backgroundColor;
+    private String borderColor;
 
     public static ChatbotTypeItem from(ChatbotType type) {
         return ChatbotTypeItem.builder()
@@ -23,6 +25,8 @@ public class ChatbotTypeItem {
                 .description(type.getDescription())
                 .imageUrl(type.getImageUrl())
                 .active(type.isActive())
+                .backgroundColor(type.getBackgroundColor())
+                .borderColor(type.getBorderColor())
                 .build();
     }
 }

--- a/src/main/java/com/wilo/server/chatbot/entity/ChatbotType.java
+++ b/src/main/java/com/wilo/server/chatbot/entity/ChatbotType.java
@@ -30,12 +30,20 @@ public class ChatbotType {
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
 
+    @Column(name = "background_color", length = 20)
+    private String backgroundColor;
+
+    @Column(name = "border_color", length = 20)
+    private String borderColor;
+
     public static ChatbotType create(
             String code,
             String name,
             String description,
             String imageUrl,
-            boolean isActive
+            boolean isActive,
+            String backgroundColor,
+            String borderColor
     ) {
         ChatbotType t = new ChatbotType();
         t.code = code;
@@ -43,6 +51,8 @@ public class ChatbotType {
         t.description = description;
         t.imageUrl = imageUrl;
         t.isActive = isActive;
+        t.backgroundColor = backgroundColor;
+        t.borderColor = borderColor;
         return t;
     }
 }

--- a/src/main/java/com/wilo/server/files/controller/FileController.java
+++ b/src/main/java/com/wilo/server/files/controller/FileController.java
@@ -3,13 +3,13 @@ package com.wilo.server.files.controller;
 import com.wilo.server.files.service.FileService;
 import com.wilo.server.global.response.CommonResponse;
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -20,18 +20,22 @@ public class FileController {
 
     private final FileService fileService;
 
-    @PostMapping("/image")
+    @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResponse<String> uploadImageFile(
-            @RequestParam("image") MultipartFile file
+            @Parameter(description = "업로드할 이미지", required = true,
+                    schema = @Schema(type = "string", format = "binary"))
+            @RequestPart("image") MultipartFile file
     ) {
         String imageUrl = fileService.uploadFileToS3(file);
-
         return CommonResponse.success(imageUrl);
     }
 
-    @PostMapping("/images")
+
+    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResponse<List<String>> uploadMultipleImageFiles(
-            @RequestParam("images") List<MultipartFile> files
+            @Parameter(description = "업로드할 이미지들", required = true,
+                    schema = @Schema(type = "string", format = "binary"))
+            @RequestPart("images") List<MultipartFile> files
     ) {
         List<String> imageUrls = files.stream()
                 .map(fileService::uploadFileToS3)
@@ -40,12 +44,12 @@ public class FileController {
         return CommonResponse.success(imageUrls);
     }
 
+
     @DeleteMapping("/image")
     public CommonResponse<String> deleteImageFile(
             @RequestParam("imageUrl") String imageUrl
     ) {
         fileService.deleteImageFileFromS3(imageUrl);
-
         return CommonResponse.success("이미지 삭제가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/wilo/server/files/service/FileService.java
+++ b/src/main/java/com/wilo/server/files/service/FileService.java
@@ -1,8 +1,10 @@
 package com.wilo.server.files.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.wilo.server.files.exception.FileErrorCase;
 import com.wilo.server.global.exception.ApplicationException;
 import java.io.IOException;
@@ -33,7 +35,15 @@ public class FileService {
         objectMetadata.setContentLength(file.getSize());
 
         try {
-            amazonS3Client.putObject(bucket, fileName, file.getInputStream(), objectMetadata);
+            PutObjectRequest putObjectRequest = new PutObjectRequest(
+                    bucket,
+                    fileName,
+                    file.getInputStream(),
+                    objectMetadata
+            ).withCannedAcl(CannedAccessControlList.PublicRead);
+
+            amazonS3Client.putObject(putObjectRequest);
+
         } catch (IOException e) {
             throw new ApplicationException(FileErrorCase.FILE_UPLOAD_FAILED);
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> S3 이미지 업로드 API를 Swagger에서 정상적으로 테스트할 수 있도록 수정하고,
업로드된 이미지가 URL로 바로 접근 가능하도록 PublicRead ACL 설정을 추가했습니다.
프론트측 요구사항으로 챗봇 타입에 배경색과 테두리색에 관련된 필드를 추가했습니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)
DB 마이그레이션 필요
```
ALTER TABLE chatbot_type
ADD COLUMN background_color VARCHAR(20),
ADD COLUMN border_color VARCHAR(20);
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 챗봇 유형에 배경색 및 테두리색 커스터마이제이션 옵션 추가로 UI 디자인 유연성 향상

* **개선 사항**
  * 파일 업로드 엔드포인트 처리 최적화
  * 클라우드 스토리지 업로드 이미지 공개 접근성 설정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->