### PR TITLE
[FEAT] 카카오,네이버 소셜 로그인 구현 

### DIFF
--- a/src/main/java/com/wilo/server/auth/controller/AuthController.java
+++ b/src/main/java/com/wilo/server/auth/controller/AuthController.java
@@ -1,13 +1,6 @@
 package com.wilo.server.auth.controller;
 
-import com.wilo.server.auth.dto.AppleLoginRequestDto;
-import com.wilo.server.auth.dto.AppleWithdrawRequestDto;
-import com.wilo.server.auth.dto.LoginRequestDto;
-import com.wilo.server.auth.dto.PhoneVerificationConfirmRequestDto;
-import com.wilo.server.auth.dto.PhoneVerificationSendRequestDto;
-import com.wilo.server.auth.dto.SignUpRequestDto;
-import com.wilo.server.auth.dto.TokenRequestDto;
-import com.wilo.server.auth.dto.TokenResponseDto;
+import com.wilo.server.auth.dto.*;
 import com.wilo.server.auth.error.AuthErrorCase;
 import com.wilo.server.auth.service.AuthService;
 import com.wilo.server.global.exception.ApplicationException;
@@ -77,6 +70,21 @@ public class AuthController {
     })
     public CommonResponse<TokenResponseDto> refreshToken(@RequestBody TokenRequestDto tokenRequestDto) {
         return CommonResponse.success(authService.refreshToken(tokenRequestDto));
+    }
+
+    @PostMapping("/kakao/login")
+    @Operation(summary = "Kakao 로그인", description = "Kakao accessToken 검증 후 로그인/회원가입 및 JWT 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Kakao accessToken 검증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<TokenResponseDto> kakaoLogin(
+            @Valid @RequestBody SocialLoginRequestDto request
+    ) {
+        return CommonResponse.success(authService.loginWithKakaoAndIssueToken(request));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/wilo/server/auth/controller/AuthController.java
+++ b/src/main/java/com/wilo/server/auth/controller/AuthController.java
@@ -87,6 +87,21 @@ public class AuthController {
         return CommonResponse.success(authService.loginWithKakaoAndIssueToken(request));
     }
 
+    @PostMapping("/naver/login")
+    @Operation(summary = "Naver 로그인", description = "Naver accessToken 검증 후 로그인/회원가입 및 JWT 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Naver accessToken 검증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<TokenResponseDto> naverLogin(
+            @Valid @RequestBody SocialLoginRequestDto request
+    ) {
+        return CommonResponse.success(authService.loginWithNaverAndIssueToken(request));
+    }
+
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "access/refresh 토큰 쿠키를 만료 처리합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/wilo/server/auth/dto/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/wilo/server/auth/dto/KakaoUserInfoResponseDto.java
@@ -1,0 +1,34 @@
+package com.wilo.server.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfoResponseDto(
+        Long id,
+
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount,
+
+        Properties properties
+) {
+    public record KakaoAccount(
+            String email
+    ) {}
+
+    public record Properties(
+            String nickname,
+            @JsonProperty("profile_image")
+            String profileImage
+    ) {}
+
+    public String email() {
+        return kakaoAccount != null ? kakaoAccount.email() : null;
+    }
+
+    public String nickname() {
+        return properties != null ? properties.nickname() : null;
+    }
+
+    public String profileImage() {
+        return properties != null ? properties.profileImage() : null;
+    }
+}

--- a/src/main/java/com/wilo/server/auth/dto/NaverUserInfoResponseDto.java
+++ b/src/main/java/com/wilo/server/auth/dto/NaverUserInfoResponseDto.java
@@ -1,0 +1,34 @@
+package com.wilo.server.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NaverUserInfoResponseDto(
+        String resultcode,
+        String message,
+        Response response
+
+) {
+    public record Response(
+            String id,
+            String email,
+            String nickname,
+            @JsonProperty("profile_image")
+            String profileImage
+    ) {}
+
+    public String id() {
+        return response != null ? response.id() : null;
+    }
+
+    public String email() {
+        return response != null ? response.email() : null;
+    }
+
+    public String nickname() {
+        return response != null ? response.nickname() : null;
+    }
+
+    public String profileImage() {
+        return response != null ? response.profileImage() : null;
+    }
+}

--- a/src/main/java/com/wilo/server/auth/dto/NaverUserInfoResponseDto.java
+++ b/src/main/java/com/wilo/server/auth/dto/NaverUserInfoResponseDto.java
@@ -3,7 +3,8 @@ package com.wilo.server.auth.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record NaverUserInfoResponseDto(
-        String resultcode,
+        @JsonProperty("resultcode")
+        String resultCode,
         String message,
         Response response
 

--- a/src/main/java/com/wilo/server/auth/dto/SocialLoginRequestDto.java
+++ b/src/main/java/com/wilo/server/auth/dto/SocialLoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.wilo.server.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SocialLoginRequestDto(
+        @NotBlank(message = "accessToken은 필수입니다.")
+        String accessToken
+) {
+}

--- a/src/main/java/com/wilo/server/auth/error/AuthErrorCase.java
+++ b/src/main/java/com/wilo/server/auth/error/AuthErrorCase.java
@@ -21,7 +21,11 @@ public enum AuthErrorCase implements ErrorCase {
     APPLE_ACCESS_TOKEN_INVALID(401, 1011, "유효하지 않은 Apple access token 입니다."),
     APPLE_CONFIG_MISSING(500, 1012, "Apple 로그인 설정이 누락되었습니다."),
     APPLE_TOKEN_EXCHANGE_FAILED(400, 1013, "Apple 토큰 교환에 실패했습니다."),
-    APPLE_TOKEN_REVOKE_FAILED(500, 1014, "Apple 토큰 철회에 실패했습니다.");
+    APPLE_TOKEN_REVOKE_FAILED(500, 1014, "Apple 토큰 철회에 실패했습니다."),
+    INVALID_KAKAO_AUTH(401, 1015, "유효하지 않은 Kakao access token 입니다."),
+    KAKAO_API_COMMUNICATION_FAILED(502, 1016, "Kakao API 통신에 실패했습니다."),
+    INVALID_NAVER_AUTH(401, 1017, "유효하지 않은 Naver access token 입니다."),
+    NAVER_API_COMMUNICATION_FAILED(502, 1018, "Naver API 통신에 실패했습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wilo/server/auth/service/AuthService.java
+++ b/src/main/java/com/wilo/server/auth/service/AuthService.java
@@ -34,6 +34,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoOAuthClient kakaoOAuthClient;
+    private final NaverOAuthClient naverOAuthClient;
 
     @Transactional
     public TokenResponseDto signUpAndIssueToken(SignUpRequestDto request) {
@@ -159,6 +160,22 @@ public class AuthService {
     }
 
     @Transactional
+    public TokenResponseDto loginWithNaverAndIssueToken(SocialLoginRequestDto request) {
+        NaverUserInfoResponseDto userInfo = naverOAuthClient.getUserInfo(request.accessToken());
+
+        String providerUserId = userInfo.id();
+        String email = userInfo.email();
+        String nickname = userInfo.nickname();
+        String profileImage = userInfo.profileImage();
+
+        User user = userRepository
+                .findByAuthProviderAndProviderUserId(AuthProvider.NAVER, providerUserId)
+                .orElseGet(() -> createNaverUser(providerUserId, email, nickname, profileImage));
+
+        return issueAndSaveTokens(user.getId());
+    }
+
+    @Transactional
     public void sendPhoneVerificationCode(PhoneVerificationSendRequestDto request) {
         String normalizedPhoneNumber = normalizePhoneNumber(request.phoneNumber());
         issuePhoneVerificationCode(normalizedPhoneNumber);
@@ -279,6 +296,35 @@ public class AuthService {
                 .phoneNumber(null)
                 .phoneVerified(false)
                 .authProvider(AuthProvider.KAKAO)
+                .providerUserId(providerUserId)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    private User createNaverUser(
+            String providerUserId,
+            String email,
+            String nickname,
+            String profileImage
+    ) {
+        String finalNickname = (nickname == null || nickname.isBlank())
+                ? generateRandomNickname()
+                : nickname;
+
+        if (userRepository.existsByNickname(finalNickname)) {
+            finalNickname = generateRandomNickname();
+        }
+
+        User user = User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .nickname(finalNickname)
+                .description(null)
+                .profileImageUrl(profileImage)
+                .phoneNumber(null)
+                .phoneVerified(false)
+                .authProvider(AuthProvider.NAVER)
                 .providerUserId(providerUserId)
                 .build();
 

--- a/src/main/java/com/wilo/server/auth/service/AuthService.java
+++ b/src/main/java/com/wilo/server/auth/service/AuthService.java
@@ -1,16 +1,10 @@
 package com.wilo.server.auth.service;
 
-import com.wilo.server.auth.dto.AppleLoginRequestDto;
-import com.wilo.server.auth.dto.AppleWithdrawRequestDto;
-import com.wilo.server.auth.dto.LoginRequestDto;
-import com.wilo.server.auth.dto.PhoneVerificationConfirmRequestDto;
-import com.wilo.server.auth.dto.PhoneVerificationSendRequestDto;
-import com.wilo.server.auth.dto.SignUpRequestDto;
-import com.wilo.server.auth.dto.TokenRequestDto;
-import com.wilo.server.auth.dto.TokenResponseDto;
+import com.wilo.server.auth.dto.*;
 import com.wilo.server.auth.error.AuthErrorCase;
 import com.wilo.server.auth.repository.PhoneVerificationCodeRepository;
 import com.wilo.server.auth.repository.RefreshTokenRepository;
+import com.wilo.server.user.entity.AuthProvider;
 import com.wilo.server.user.entity.User;
 import com.wilo.server.user.repository.UserRepository;
 import com.wilo.server.global.config.security.jwt.JwtTokenProvider;
@@ -39,6 +33,7 @@ public class AuthService {
     private final AppleOAuthClient appleOAuthClient;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     @Transactional
     public TokenResponseDto signUpAndIssueToken(SignUpRequestDto request) {
@@ -56,6 +51,9 @@ public class AuthService {
                         .description(null)
                         .profileImageUrl(null)
                         .phoneNumber(normalizedPhoneNumber)
+                        .phoneVerified(false)
+                        .authProvider(AuthProvider.LOCAL)
+                        .providerUserId(null)
                         .build()
         );
 
@@ -81,7 +79,7 @@ public class AuthService {
         AppleOAuthClient.AppleIdentityClaims claims = appleOAuthClient.verifyAccessToken(request.accessToken());
         String appleSyntheticEmail = buildAppleEmailFromSubject(claims.subject());
 
-        User user = userRepository.findByEmail(appleSyntheticEmail)
+        User user = userRepository.findByAuthProviderAndProviderUserId(AuthProvider.APPLE, claims.subject())
                 .orElseGet(() -> userRepository.save(
                         User.builder()
                                 .email(appleSyntheticEmail)
@@ -90,6 +88,9 @@ public class AuthService {
                                 .description(null)
                                 .profileImageUrl(null)
                                 .phoneNumber(null)
+                                .phoneVerified(false)
+                                .authProvider(AuthProvider.APPLE)
+                                .providerUserId(claims.subject())
                                 .build()
                 ));
 
@@ -139,6 +140,22 @@ public class AuthService {
         appleOAuthClient.revokeByAuthorizationCode(request.authorizationCode());
         refreshTokenRepository.deleteByUserId(userId);
         userRepository.delete(user);
+    }
+
+    @Transactional
+    public TokenResponseDto loginWithKakaoAndIssueToken(SocialLoginRequestDto request) {
+        KakaoUserInfoResponseDto userInfo = kakaoOAuthClient.getUserInfo(request.accessToken());
+
+        String providerUserId = String.valueOf(userInfo.id());
+        String email = userInfo.email();
+        String nickname = userInfo.nickname();
+        String profileImage = userInfo.profileImage();
+
+        User user = userRepository
+                .findByAuthProviderAndProviderUserId(AuthProvider.KAKAO, providerUserId)
+                .orElseGet(() -> createKakaoUser(providerUserId, email, nickname, profileImage));
+
+        return issueAndSaveTokens(user.getId());
     }
 
     @Transactional
@@ -237,5 +254,47 @@ public class AuthService {
     private String createVerificationCode() {
         int code = SECURE_RANDOM.nextInt(1_000_000);
         return String.format("%06d", code);
+    }
+
+    private User createKakaoUser(
+            String providerUserId,
+            String email,
+            String nickname,
+            String profileImage
+    ) {
+        String finalNickname = (nickname == null || nickname.isBlank())
+                ? generateRandomNickname()
+                : nickname;
+
+        if (userRepository.existsByNickname(finalNickname)) {
+            finalNickname = generateRandomNickname();
+        }
+
+        User user = User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .nickname(finalNickname)
+                .description(null)
+                .profileImageUrl(profileImage)
+                .phoneNumber(null)
+                .phoneVerified(false)
+                .authProvider(AuthProvider.KAKAO)
+                .providerUserId(providerUserId)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    private String generateRandomNickname() {
+        String candidate;
+
+        do {
+            candidate = "user_" + UUID.randomUUID()
+                    .toString()
+                    .replace("-", "")
+                    .substring(0, 8);
+        } while (userRepository.existsByNickname(candidate));
+
+        return candidate;
     }
 }

--- a/src/main/java/com/wilo/server/auth/service/AuthService.java
+++ b/src/main/java/com/wilo/server/auth/service/AuthService.java
@@ -154,7 +154,8 @@ public class AuthService {
 
         User user = userRepository
                 .findByAuthProviderAndProviderUserId(AuthProvider.KAKAO, providerUserId)
-                .orElseGet(() -> createKakaoUser(providerUserId, email, nickname, profileImage));
+                .orElseGet(() -> createSocialUser(AuthProvider.KAKAO, providerUserId, email, nickname, profileImage));
+
 
         return issueAndSaveTokens(user.getId());
     }
@@ -170,7 +171,7 @@ public class AuthService {
 
         User user = userRepository
                 .findByAuthProviderAndProviderUserId(AuthProvider.NAVER, providerUserId)
-                .orElseGet(() -> createNaverUser(providerUserId, email, nickname, profileImage));
+                .orElseGet(() -> createSocialUser(AuthProvider.NAVER, providerUserId, email, nickname, profileImage));
 
         return issueAndSaveTokens(user.getId());
     }
@@ -273,19 +274,14 @@ public class AuthService {
         return String.format("%06d", code);
     }
 
-    private User createKakaoUser(
+    private User createSocialUser(
+            AuthProvider authProvider,
             String providerUserId,
             String email,
             String nickname,
             String profileImage
     ) {
-        String finalNickname = (nickname == null || nickname.isBlank())
-                ? generateRandomNickname()
-                : nickname;
-
-        if (userRepository.existsByNickname(finalNickname)) {
-            finalNickname = generateRandomNickname();
-        }
+        String finalNickname = resolveUniqueNickname(nickname);
 
         User user = User.builder()
                 .email(email)
@@ -295,40 +291,21 @@ public class AuthService {
                 .profileImageUrl(profileImage)
                 .phoneNumber(null)
                 .phoneVerified(false)
-                .authProvider(AuthProvider.KAKAO)
+                .authProvider(authProvider)
                 .providerUserId(providerUserId)
                 .build();
 
         return userRepository.save(user);
     }
 
-    private User createNaverUser(
-            String providerUserId,
-            String email,
-            String nickname,
-            String profileImage
-    ) {
-        String finalNickname = (nickname == null || nickname.isBlank())
-                ? generateRandomNickname()
-                : nickname;
-
-        if (userRepository.existsByNickname(finalNickname)) {
-            finalNickname = generateRandomNickname();
+    private String resolveUniqueNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            return generateRandomNickname();
         }
-
-        User user = User.builder()
-                .email(email)
-                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
-                .nickname(finalNickname)
-                .description(null)
-                .profileImageUrl(profileImage)
-                .phoneNumber(null)
-                .phoneVerified(false)
-                .authProvider(AuthProvider.NAVER)
-                .providerUserId(providerUserId)
-                .build();
-
-        return userRepository.save(user);
+        if (userRepository.existsByNickname(nickname)) {
+            return generateRandomNickname();
+        }
+        return nickname;
     }
 
     private String generateRandomNickname() {

--- a/src/main/java/com/wilo/server/auth/service/KakaoOAuthClient.java
+++ b/src/main/java/com/wilo/server/auth/service/KakaoOAuthClient.java
@@ -1,0 +1,39 @@
+package com.wilo.server.auth.service;
+
+import com.wilo.server.auth.dto.KakaoUserInfoResponseDto;
+import com.wilo.server.auth.error.AuthErrorCase;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+    private static final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    private final WebClient.Builder webClientBuilder;
+
+    public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+
+        try {
+            KakaoUserInfoResponseDto response = webClientBuilder.build()
+                    .get()
+                    .uri(USER_INFO_URI)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfoResponseDto.class)
+                    .block();
+
+            if (response == null || response.id() == null) {
+                throw ApplicationException.from(AuthErrorCase.INVALID_KAKAO_AUTH);
+            }
+
+            return response;
+
+        } catch (Exception e) {
+            throw new ApplicationException(AuthErrorCase.KAKAO_API_COMMUNICATION_FAILED, e);
+        }
+    }
+}

--- a/src/main/java/com/wilo/server/auth/service/NaverOAuthClient.java
+++ b/src/main/java/com/wilo/server/auth/service/NaverOAuthClient.java
@@ -1,0 +1,38 @@
+package com.wilo.server.auth.service;
+
+import com.wilo.server.auth.dto.NaverUserInfoResponseDto;
+import com.wilo.server.auth.error.AuthErrorCase;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class NaverOAuthClient {
+    private static final String USER_INFO_URI = "https://openapi.naver.com/v1/nid/me";
+    private final WebClient.Builder webClientBuilder;
+
+    public NaverUserInfoResponseDto getUserInfo(String accessToken) {
+        try {
+            NaverUserInfoResponseDto response =
+                    webClientBuilder.build()
+                            .get()
+                            .uri(USER_INFO_URI)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .retrieve()
+                            .bodyToMono(NaverUserInfoResponseDto.class)
+                            .block();
+
+            if (response == null || response.id() == null) {
+                throw ApplicationException.from(AuthErrorCase.INVALID_NAVER_AUTH);
+            }
+
+            return response;
+
+        } catch (Exception e) {
+            throw new ApplicationException(AuthErrorCase.NAVER_API_COMMUNICATION_FAILED, e);
+        }
+    }
+}

--- a/src/main/java/com/wilo/server/auth/service/NaverOAuthClient.java
+++ b/src/main/java/com/wilo/server/auth/service/NaverOAuthClient.java
@@ -31,6 +31,8 @@ public class NaverOAuthClient {
 
             return response;
 
+        } catch (ApplicationException e) {
+            throw e;
         } catch (Exception e) {
             throw new ApplicationException(AuthErrorCase.NAVER_API_COMMUNICATION_FAILED, e);
         }

--- a/src/main/java/com/wilo/server/user/entity/AuthProvider.java
+++ b/src/main/java/com/wilo/server/user/entity/AuthProvider.java
@@ -1,0 +1,8 @@
+package com.wilo.server.user.entity;
+
+public enum AuthProvider {
+    LOCAL,
+    APPLE,
+    KAKAO,
+    NAVER
+}

--- a/src/main/java/com/wilo/server/user/entity/User.java
+++ b/src/main/java/com/wilo/server/user/entity/User.java
@@ -12,7 +12,12 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
-@Table(name = "users")
+@Table(name = "users", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_users_auth_provider_provider_user_id",
+                columnNames = {"auth_provider", "provider_user_id"}
+        )
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE users SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")

--- a/src/main/java/com/wilo/server/user/entity/User.java
+++ b/src/main/java/com/wilo/server/user/entity/User.java
@@ -70,7 +70,7 @@ public class User extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
         this.phoneNumber = phoneNumber;
         this.phoneVerified = phoneVerified;
-        this.authProvider = authProvider;
+        this.authProvider = authProvider != null ? authProvider : AuthProvider.LOCAL;
         this.providerUserId = providerUserId;
     }
 

--- a/src/main/java/com/wilo/server/user/entity/User.java
+++ b/src/main/java/com/wilo/server/user/entity/User.java
@@ -2,13 +2,7 @@ package com.wilo.server.user.entity;
 
 import com.wilo.server.global.entity.BaseEntity;
 import com.wilo.server.user.service.CryptoConverter;
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,8 +44,25 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private boolean phoneVerified;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AuthProvider authProvider;
+
+    @Column(length = 100)
+    private String providerUserId;
+
     @Builder
-    private User(String email, String password, String nickname, String description, String profileImageUrl, String phoneNumber, boolean phoneVerified) {
+    private User(
+            String email,
+            String password,
+            String nickname,
+            String description,
+            String profileImageUrl,
+            String phoneNumber,
+            boolean phoneVerified,
+            AuthProvider authProvider,
+            String providerUserId
+    ) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
@@ -59,6 +70,8 @@ public class User extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
         this.phoneNumber = phoneNumber;
         this.phoneVerified = phoneVerified;
+        this.authProvider = authProvider;
+        this.providerUserId = providerUserId;
     }
 
     public void updateProfile(String nickname, String description, String phoneNumber) {

--- a/src/main/java/com/wilo/server/user/repository/UserRepository.java
+++ b/src/main/java/com/wilo/server/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.wilo.server.user.repository;
 
 import com.wilo.server.user.entity.User;
+
+import com.wilo.server.user.entity.AuthProvider;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhoneNumber(String phoneNumber);
 
     List<User> findAllByPhoneNumber(String phoneNumber);
+
+    Optional<User> findByAuthProviderAndProviderUserId(AuthProvider authProvider, String providerUserId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #57 

## 📝 작업 내용

모바일 앱 기반 OAuth Kakao / Naver 소셜 로그인 기능을 구현했습니다.

**1. Kakao 소셜 로그인 구현**
- `POST /api/v1/auth/kakao/login` API 추가
- 프론트에서 전달받은 Kakao accessToken을 이용해 사용자 정보 조회
- 사용자 조회 후 기존 사용자 로그인 또는 신규 사용자 생성
- JWT Access / Refresh Token 발급

**2. Naver 소셜 로그인 구현**
- `POST /api/v1/auth/naver/login` API 추가
- 프론트에서 전달받은 Naver accessToken을 이용해  사용자 정보 조회
- 사용자 조회 후 기존 사용자 로그인 또는 신규 사용자 생성
- JWT Access / Refresh Token 발급

**3. AuthProvider 추가**
소셜 로그인 제공자를 구분하기 위해 `AuthProvider` enum을 추가했습니다.

```
LOCAL
APPLE
KAKAO
NAVER
```


## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)
현재 유저 엔티티에 auth_provider,provider_user_id 두개의 필드가 추가되어
```
ALTER TABLE users
ADD COLUMN auth_provider VARCHAR(20) NOT NULL DEFAULT 'LOCAL',
ADD COLUMN provider_user_id VARCHAR(100);
```

DB 마이그레이션이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Kakao 소셜 로그인 지원 추가
  * Naver 소셜 로그인 지원 추가
  * 소셜 로그인 시 신규 사용자 생성 및 연동 흐름 개선

* **Bug Fixes**
  * Apple 로그인 인증/가입 흐름 안정성 개선
  * 외부 소셜 API 통신 실패 및 인증 오류 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->