### PR TITLE
[REFACTOR] 프론트 요구사항 반영 

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatSessionRepository.java
@@ -26,6 +26,7 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
                 (:guestId is not null and cs.guestId = :guestId)
             )
           and cs.status = :status
+          and cs.lastMessageAt is not null
           and (
                 :cursorActivityAt is null
                 or (

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -74,18 +74,20 @@ public class ChatMessageTxService {
                 .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
 
         // 첫 메시지라면 title 업데이트
-        if ("새로운 대화".equals(session.getTitle())) {
+        if ("새로운 대화".equals(session.getTitle())
+                && request.getMessageType() == MessageType.TEXT
+                && request.getMessage() != null) {
             String title = request.getMessage().trim();
-
-            if (title.length() > 30) {
-                title = title.substring(0, 30);
+            if (!title.isEmpty()) {
+                if (title.length() > 30) {
+                    title = title.substring(0, 30);
+                }
+                session.updateTitle(title);
             }
-
-            session.updateTitle(title);
         }
 
         // 마지막 메시지 시간 업데이트
-        session.updateLastMessageAt(LocalDateTime.now());
+        session.updateLastMessageAt(saved.getCreatedAt());
 
         List<Long> mediaIds = request.getMediaIds();
         if (mediaIds != null && !mediaIds.isEmpty()) {

--- a/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatMessageTxService.java
@@ -21,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -59,7 +61,6 @@ public class ChatMessageTxService {
 
     @Transactional
     public ChatMessage saveUserMessage(Long sessionId, ChatMessageSendRequest request) {
-
         ChatMessage message = ChatMessage.createUser(
                 sessionId,
                 request.getMessageType(),
@@ -68,13 +69,31 @@ public class ChatMessageTxService {
 
         ChatMessage saved = chatMessageRepository.save(message);
 
+        // 세션 조회
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ApplicationException(ChatbotErrorCase.SESSION_NOT_FOUND));
+
+        // 첫 메시지라면 title 업데이트
+        if ("새로운 대화".equals(session.getTitle())) {
+            String title = request.getMessage().trim();
+
+            if (title.length() > 30) {
+                title = title.substring(0, 30);
+            }
+
+            session.updateTitle(title);
+        }
+
+        // 마지막 메시지 시간 업데이트
+        session.updateLastMessageAt(LocalDateTime.now());
+
         List<Long> mediaIds = request.getMediaIds();
         if (mediaIds != null && !mediaIds.isEmpty()) {
 
-            // media 존재 검증 (중복 검증 포함)
+            // media 존재 검증
             List<Long> distinctMediaIds = mediaIds.stream().distinct().toList();
             List<Media> medias = mediaRepository.findAllById(distinctMediaIds);
-            if (medias.size() != distinctMediaIds.size()){
+            if (medias.size() != distinctMediaIds.size()) {
                 throw new ApplicationException(MediaErrorCase.MEDIA_NOT_FOUND);
             }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

**1. 메시지가 없는 세션은 보관함에 노출되지 않도록 보관함 조회 시 lastMessageAt이 있는 세션만 내려주도록 수정했습니다.**
- 따라서 세션 생성 후 **메시지를 입력하지 않은 경우 보관함 목록에는 나타나지 않습니다.**


**2. 세션 title은 별도의 필드로 관리되고 있으며 현재 기본값은 "새로운 대화"입니다.**
- 첫 사용자 메시지가 입력되면 **해당 메시지를 기준으로 세션 title을 업데이트하도록 수정**했습니다.
- 그래서 이후 보관함에서는 **첫 사용자 메시지를 기반으로 세션 제목이 표시**됩니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 세션 제목이 사용자의 첫 메시지를 기반으로 자동 생성되며, 길이는 최대 30자로 요약됩니다.

* **버그 수정**
  * 새 메시지 저장 시 세션의 마지막 메시지 시간이 즉시 업데이트되어 표시가 정확해졌습니다.
  * 메시지가 없는(빈) 세션은 목록에서 제외되어 관련 보기의 노이즈가 줄어듭니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->