### PR TITLE
[feat] AI 챗봇 첫 대화 생성 API 구현 

### DIFF
--- a/src/main/java/com/wilo/server/chatbot/client/AiGreetingClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiGreetingClient.java
@@ -1,0 +1,5 @@
+package com.wilo.server.chatbot.client;
+
+public interface AiGreetingClient {
+    AiChatResult greeting(AiGreetingCommand command);
+}

--- a/src/main/java/com/wilo/server/chatbot/client/AiGreetingCommand.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiGreetingCommand.java
@@ -1,8 +1,10 @@
 package com.wilo.server.chatbot.client;
 
+import com.wilo.server.chatbot.client.dto.AiRoleMessage;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -13,6 +15,6 @@ public class AiGreetingCommand {
     private Long sessionId;
     private String personaId;
     private String sessionSummary;
-    private java.util.List<com.wilo.server.chatbot.client.dto.AiRoleMessage> recentMessages;
+    private List<AiRoleMessage> recentMessages;
     private Map<String, Object> memory;
 }

--- a/src/main/java/com/wilo/server/chatbot/client/AiGreetingCommand.java
+++ b/src/main/java/com/wilo/server/chatbot/client/AiGreetingCommand.java
@@ -1,0 +1,18 @@
+package com.wilo.server.chatbot.client;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class AiGreetingCommand {
+    private String requestId;
+    private String userId;
+    private Long sessionId;
+    private String personaId;
+    private String sessionSummary;
+    private java.util.List<com.wilo.server.chatbot.client.dto.AiRoleMessage> recentMessages;
+    private Map<String, Object> memory;
+}

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiGreetingClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiGreetingClient.java
@@ -43,7 +43,7 @@ public class RealAiGreetingClient implements AiGreetingClient {
                 .bodyValue(req)
                 .retrieve()
                 .onStatus(
-                        s -> s.value() == 502 || s.value() == 503 || s.value() == 504,
+                        s -> s.is5xxServerError(),
                         r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED))
                 )
                 .onStatus(

--- a/src/main/java/com/wilo/server/chatbot/client/RealAiGreetingClient.java
+++ b/src/main/java/com/wilo/server/chatbot/client/RealAiGreetingClient.java
@@ -1,0 +1,77 @@
+package com.wilo.server.chatbot.client;
+
+import com.wilo.server.chatbot.client.dto.AiChatRequest;
+import com.wilo.server.chatbot.client.dto.AiChatResponse;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class RealAiGreetingClient implements AiGreetingClient {
+
+    private final WebClient aiWebClient;
+
+    @Override
+    public AiChatResult greeting(AiGreetingCommand command) {
+
+        AiChatRequest.Context context = AiChatRequest.Context.builder()
+                .recentMessages(command.getRecentMessages() == null ? List.of() : command.getRecentMessages())
+                .sessionSummary(command.getSessionSummary() == null ? "" : command.getSessionSummary())
+                .memory(command.getMemory() == null ? Map.of() : command.getMemory())
+                .build();
+
+        AiChatRequest req = AiChatRequest.builder()
+                .requestId(command.getRequestId())
+                .userId(command.getUserId())
+                .sessionId(String.valueOf(command.getSessionId()))
+                .personaId(command.getPersonaId())
+                .context(context)
+                .build();
+
+        AiChatResponse res = aiWebClient.post()
+                .uri("/greeting")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(req)
+                .retrieve()
+                .onStatus(
+                        s -> s.value() == 502 || s.value() == 503 || s.value() == 504,
+                        r -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED))
+                )
+                .onStatus(
+                        s -> s.is4xxClientError(),
+                        r -> r.bodyToMono(String.class)
+                                .flatMap(body -> Mono.error(new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID)))
+                )
+                .bodyToMono(AiChatResponse.class)
+                .timeout(Duration.ofSeconds(35))
+                .block();
+
+        if (res == null) {
+            throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
+        }
+
+        if (res.getStatus() != null && !"success".equalsIgnoreCase(res.getStatus())) {
+            throw new ApplicationException(ChatbotErrorCase.AI_SERVER_FAILED);
+        }
+
+        if (res.getAnswer() == null || res.getAnswer().isBlank()) {
+            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+        }
+
+        return AiChatResult.builder()
+                .sessionId(command.getSessionId())
+                .answer(res.getAnswer())
+                .choices(res.getChoices() == null ? List.of() : res.getChoices())
+                .safetyStatus(AiSafetyMapper.toBackend(res.getSafetyStatus()))
+                .build();
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatGreetingController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatGreetingController.java
@@ -1,0 +1,57 @@
+package com.wilo.server.chatbot.controller;
+
+import com.wilo.server.chatbot.dto.ChatGreetingResponse;
+import com.wilo.server.chatbot.service.ChatGreetingService;
+import com.wilo.server.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat/sessions")
+public class ChatGreetingController {
+
+    private final ChatGreetingService chatGreetingService;
+
+    @PostMapping("/{sessionId}/greeting")
+    @Operation(
+            summary = "챗봇 첫 대화 생성",
+            description = """
+                채팅방 첫 진입 시 AI 서버 /greeting을 호출하여 챗봇의 첫 인사 메시지를 생성합니다.
+                - 로그인 사용자는 JWT userId 기준
+                - 비로그인 사용자는 X-Guest-Id 기준
+                - 이미 세션에 메시지가 존재하면 greeting을 중복 생성하지 않고 기존 첫 BOT 메시지를 반환합니다.
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "greeting 생성/조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 게스트 식별자 누락",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "세션 접근 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "세션 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "502", description = "AI 서버 오류/응답 형식 불일치",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<ChatGreetingResponse> createGreeting(
+            @Parameter(description = "세션 ID", example = "101")
+            @Min(value = 1, message = "sessionId는 1 이상이어야 합니다.")
+            @PathVariable Long sessionId,
+            @Parameter(description = "비로그인 사용자 UUID. 비로그인 요청 시 필수", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Guest-Id", required = false) String guestId
+    ) {
+        return CommonResponse.success(
+                chatGreetingService.createOrGetGreeting(sessionId, guestId)
+        );
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/controller/ChatGreetingController.java
+++ b/src/main/java/com/wilo/server/chatbot/controller/ChatGreetingController.java
@@ -11,11 +11,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chat/sessions")
+@Validated
 public class ChatGreetingController {
 
     private final ChatGreetingService chatGreetingService;

--- a/src/main/java/com/wilo/server/chatbot/dto/ChatGreetingResponse.java
+++ b/src/main/java/com/wilo/server/chatbot/dto/ChatGreetingResponse.java
@@ -1,0 +1,11 @@
+package com.wilo.server.chatbot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatGreetingResponse {
+    private Long sessionId;
+    private ChatMessageDto botMessage;
+}

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -97,13 +97,25 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         select m
         from ChatMessage m
         where m.sessionId = :sessionId
-        and m.senderType = :senderType
+          and m.senderType = com.wilo.server.chatbot.entity.SenderType.BOT
         order by m.id asc
     """)
     List<ChatMessage> findBotMessagesBySessionIdAsc(
             @Param("sessionId") Long sessionId,
-            @Param("senderType") SenderType senderType,
-            Pageable pageable);
+            Pageable pageable
+    );
+
+    @Query("""
+        select m
+        from ChatMessage m
+        where m.sessionId = :sessionId
+          and m.senderType = com.wilo.server.chatbot.entity.SenderType.BOT
+        order by m.id asc
+    """)
+    List<ChatMessage> findFirstBotMessage(
+            @Param("sessionId") Long sessionId,
+            Pageable pageable
+    );
 
     Optional<ChatMessage> findById(Long id);
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.wilo.server.chatbot.repository;
 
 import com.wilo.server.chatbot.entity.ChatMessage;
+import com.wilo.server.chatbot.entity.SenderType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -96,10 +97,13 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         select m
         from ChatMessage m
         where m.sessionId = :sessionId
-        and m.senderType = com.wilo.server.chatbot.entity.SenderType.BOT
+        and m.senderType = :senderType
         order by m.id asc
     """)
-    List<ChatMessage> findBotMessagesBySessionIdAsc(@Param("sessionId") Long sessionId, Pageable pageable);
+    List<ChatMessage> findBotMessagesBySessionIdAsc(
+            @Param("sessionId") Long sessionId,
+            @Param("senderType") SenderType senderType,
+            Pageable pageable);
 
     Optional<ChatMessage> findById(Long id);
 }

--- a/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wilo/server/chatbot/repository/ChatMessageRepository.java
@@ -84,5 +84,22 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     """)
     int deleteBySessionIds(@Param("sessionIds") Collection<Long> sessionIds);
 
+    @Query("""
+        select m
+        from ChatMessage m
+        where m.sessionId = :sessionId
+        order by m.id asc
+    """)
+    List<ChatMessage> findAllBySessionIdOrderByIdAsc(@Param("sessionId") Long sessionId);
+
+    @Query("""
+        select m
+        from ChatMessage m
+        where m.sessionId = :sessionId
+        and m.senderType = com.wilo.server.chatbot.entity.SenderType.BOT
+        order by m.id asc
+    """)
+    List<ChatMessage> findBotMessagesBySessionIdAsc(@Param("sessionId") Long sessionId, Pageable pageable);
+
     Optional<ChatMessage> findById(Long id);
 }

--- a/src/main/java/com/wilo/server/chatbot/service/ChatGreetingService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatGreetingService.java
@@ -60,7 +60,7 @@ public class ChatGreetingService {
                         .userId(requester)
                         .sessionId(sessionId)
                         .personaId(personaCode)
-                        .sessionSummary(chatMessageTxService.getSessionSummary(sessionId))
+                        .sessionSummary(null)
                         .recentMessages(java.util.List.of())
                         .memory(null)
                         .build()

--- a/src/main/java/com/wilo/server/chatbot/service/ChatGreetingService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatGreetingService.java
@@ -1,0 +1,93 @@
+package com.wilo.server.chatbot.service;
+
+import com.wilo.server.chatbot.client.AiChatResult;
+import com.wilo.server.chatbot.client.AiGreetingClient;
+import com.wilo.server.chatbot.client.AiGreetingCommand;
+import com.wilo.server.chatbot.dto.ChatGreetingResponse;
+import com.wilo.server.chatbot.entity.ChatMessage;
+import com.wilo.server.chatbot.exception.ChatbotErrorCase;
+import com.wilo.server.chatbot.repository.ChatMessageRepository;
+import com.wilo.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatGreetingService {
+
+    private final AiGreetingClient aiGreetingClient;
+    private final ChatMessageTxService chatMessageTxService;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public ChatGreetingResponse createOrGetGreeting(Long sessionId, String guestIdHeader) {
+
+        Long userId = extractUserIdIfAuthenticated();
+        String guestId = normalizeGuestId(guestIdHeader);
+
+        if (userId == null && guestId == null) {
+            throw new ApplicationException(ChatbotErrorCase.GUEST_ID_REQUIRED);
+        }
+
+        // 세션 접근 검증 + persona
+        String personaCode = chatMessageTxService.getPersonaCodeWithAuthCheck(sessionId, userId, guestId);
+
+        // 이미 메시지가 있으면 greeting 중복 생성하지 않고 첫 BOT 반환
+        var existingMessages = chatMessageRepository.findBySessionIdCursorDesc(sessionId, null, PageRequest.of(0, 1));
+        if (!existingMessages.isEmpty()) {
+            ChatMessage existingFirstBot = chatMessageRepository
+                    .findAllBySessionIdOrderByIdAsc(sessionId)
+                    .stream()
+                    .filter(m -> m.getSenderType().name().equals("BOT"))
+                    .findFirst()
+                    .orElse(existingMessages.get(0));
+
+            return ChatGreetingResponse.builder()
+                    .sessionId(sessionId)
+                    .botMessage(chatMessageTxService.toDto(existingFirstBot))
+                    .build();
+        }
+
+        String requester = (userId != null) ? String.valueOf(userId) : guestId;
+        String requestId = java.util.UUID.randomUUID().toString();
+
+        AiChatResult aiResult = aiGreetingClient.greeting(
+                AiGreetingCommand.builder()
+                        .requestId(requestId)
+                        .userId(requester)
+                        .sessionId(sessionId)
+                        .personaId(personaCode)
+                        .sessionSummary(chatMessageTxService.getSessionSummary(sessionId))
+                        .recentMessages(java.util.List.of())
+                        .memory(null)
+                        .build()
+        );
+
+        if (aiResult == null || aiResult.getAnswer() == null) {
+            throw new ApplicationException(ChatbotErrorCase.AI_RESPONSE_INVALID);
+        }
+
+        ChatMessage savedBot = chatMessageTxService.saveBotMessageWithSessionUpdate(sessionId, aiResult);
+
+        return ChatGreetingResponse.builder()
+                .sessionId(sessionId)
+                .botMessage(chatMessageTxService.toDto(savedBot))
+                .build();
+    }
+
+    private String normalizeGuestId(String guestIdHeader) {
+        if (guestIdHeader == null) return null;
+        String trimmed = guestIdHeader.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private Long extractUserIdIfAuthenticated() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) return null;
+        if (auth.getPrincipal() instanceof Long userId) return userId;
+        return null;
+    }
+}

--- a/src/main/java/com/wilo/server/chatbot/service/ChatGreetingService.java
+++ b/src/main/java/com/wilo/server/chatbot/service/ChatGreetingService.java
@@ -35,19 +35,12 @@ public class ChatGreetingService {
         // 세션 접근 검증 + persona
         String personaCode = chatMessageTxService.getPersonaCodeWithAuthCheck(sessionId, userId, guestId);
 
-        // 이미 메시지가 있으면 greeting 중복 생성하지 않고 첫 BOT 반환
-        var existingMessages = chatMessageRepository.findBySessionIdCursorDesc(sessionId, null, PageRequest.of(0, 1));
-        if (!existingMessages.isEmpty()) {
-            ChatMessage existingFirstBot = chatMessageRepository
-                    .findAllBySessionIdOrderByIdAsc(sessionId)
-                    .stream()
-                    .filter(m -> m.getSenderType().name().equals("BOT"))
-                    .findFirst()
-                    .orElse(existingMessages.get(0));
-
+        // 첫 번째 BOT 메시지만 조회 (없으면 빈 리스트)
+        var botMessages = chatMessageRepository.findBotMessagesBySessionIdAsc(sessionId, PageRequest.of(0, 1));
+        if (!botMessages.isEmpty()) {
             return ChatGreetingResponse.builder()
                     .sessionId(sessionId)
-                    .botMessage(chatMessageTxService.toDto(existingFirstBot))
+                    .botMessage(chatMessageTxService.toDto(botMessages.get(0)))
                     .build();
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #62 

## 📝 작업 내용

> 현재는 사용자가 AI 챗봇한테 메시지 전송만 가능한데, 첫 대화창이 생성되면 AI 챗봇이 사용자한테 첫 대화를 생성해야하기때문에 해당 관련 API를 구현했습니다.  

## 🖼️ 스크린샷 (선택)
### 챗봇 첫 대화 응답 성공
<img width="1465" height="943" alt="화면 캡처 2026-03-24 172846" src="https://github.com/user-attachments/assets/6b704c7e-55c6-4b1b-a71f-7670fca82114" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 세션 시작 시 AI 기반 인사말 생성 및 노출을 위한 API와 서비스 추가
  * 세션별 개인화된 초대 메시지(페르소나 기반) 제공
  * 기존 인사말 중복 저장을 방지해 일관된 세션 경험 보장
  * 인사말 응답 검증 및 오류 처리로 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->