### PR TITLE
[FEAT] 애플 로그인 검증 로직 개선

### DIFF
--- a/src/main/java/com/wilo/server/auth/controller/AuthController.java
+++ b/src/main/java/com/wilo/server/auth/controller/AuthController.java
@@ -52,11 +52,11 @@ public class AuthController {
     }
 
     @PostMapping("/apple/login")
-    @Operation(summary = "Apple 로그인", description = "Apple accessToken 검증 후 로그인/회원가입 및 JWT 토큰을 발급합니다.")
+    @Operation(summary = "Apple 로그인", description = "Apple authorizationCode를 서버에서 교환하고 identityToken을 검증한 뒤 로그인/회원가입 및 JWT 토큰을 발급합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(responseCode = "400", description = "요청값 검증 실패", content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Apple accessToken 검증 실패", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+            @ApiResponse(responseCode = "401", description = "Apple 인증 정보 검증 실패", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<TokenResponseDto> appleLogin(@Valid @RequestBody AppleLoginRequestDto request) {
         return CommonResponse.success(authService.loginWithAppleAndIssueToken(request));

--- a/src/main/java/com/wilo/server/auth/dto/AppleLoginRequestDto.java
+++ b/src/main/java/com/wilo/server/auth/dto/AppleLoginRequestDto.java
@@ -3,7 +3,9 @@ package com.wilo.server.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record AppleLoginRequestDto(
-        @NotBlank(message = "Apple accessToken은 필수입니다.")
-        String accessToken
+        @NotBlank(message = "Apple authorizationCode는 필수입니다.")
+        String authorizationCode,
+        @NotBlank(message = "Apple identityToken은 필수입니다.")
+        String identityToken
 ) {
 }

--- a/src/main/java/com/wilo/server/auth/service/AppleOAuthClient.java
+++ b/src/main/java/com/wilo/server/auth/service/AppleOAuthClient.java
@@ -45,11 +45,52 @@ public class AppleOAuthClient {
     private volatile Map<String, PublicKey> cachedPublicKeys = Map.of();
     private volatile long cachedAtMillis = 0L;
 
-    public AppleIdentityClaims verifyAccessToken(String accessToken) {
+    public AppleTokenExchangeResult exchangeAuthorizationCode(String authorizationCode) {
         validateAppleConfig();
 
         try {
-            String[] jwtParts = accessToken.split("\\.");
+            WebClient webClient = webClientBuilder.build();
+            String clientSecret = generateClientSecret();
+
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add("grant_type", "authorization_code");
+            formData.add("code", authorizationCode);
+            formData.add("client_id", properties.getClientId());
+            formData.add("client_secret", clientSecret);
+
+            JsonNode response = webClient.post()
+                    .uri(properties.getTokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(formData))
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null) {
+                throw ApplicationException.from(AuthErrorCase.APPLE_TOKEN_EXCHANGE_FAILED);
+            }
+
+            String accessToken = response.path("access_token").asText("");
+            String identityToken = response.path("id_token").asText("");
+            String refreshToken = response.path("refresh_token").asText("");
+
+            if (accessToken.isBlank() || identityToken.isBlank()) {
+                throw ApplicationException.from(AuthErrorCase.APPLE_TOKEN_EXCHANGE_FAILED);
+            }
+
+            return new AppleTokenExchangeResult(accessToken, identityToken, refreshToken);
+        } catch (ApplicationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ApplicationException(AuthErrorCase.APPLE_TOKEN_EXCHANGE_FAILED, e);
+        }
+    }
+
+    public AppleIdentityClaims verifyIdentityToken(String identityToken) {
+        validateAppleConfig();
+
+        try {
+            String[] jwtParts = identityToken.split("\\.");
             if (jwtParts.length != 3) {
                 throw ApplicationException.from(AuthErrorCase.APPLE_ACCESS_TOKEN_INVALID);
             }
@@ -68,7 +109,7 @@ public class AppleOAuthClient {
             Claims claims = Jwts.parserBuilder()
                     .setSigningKey(publicKey)
                     .build()
-                    .parseClaimsJws(accessToken)
+                    .parseClaimsJws(identityToken)
                     .getBody();
 
             if (!properties.getIssuer().equals(claims.getIssuer())) {
@@ -93,11 +134,17 @@ public class AppleOAuthClient {
 
     public void revokeByAuthorizationCode(String authorizationCode) {
         validateAppleConfig();
-        String refreshToken = exchangeAuthorizationCode(authorizationCode);
-        revokeRefreshToken(refreshToken);
+        AppleTokenExchangeResult tokenExchangeResult = exchangeAuthorizationCode(authorizationCode);
+        if (tokenExchangeResult.refreshToken().isBlank()) {
+            throw ApplicationException.from(AuthErrorCase.APPLE_TOKEN_EXCHANGE_FAILED);
+        }
+        revokeRefreshToken(tokenExchangeResult.refreshToken());
     }
 
     public record AppleIdentityClaims(String subject, String email) {
+    }
+
+    public record AppleTokenExchangeResult(String accessToken, String identityToken, String refreshToken) {
     }
 
     private PublicKey resolvePublicKey(String kid) {
@@ -158,37 +205,6 @@ public class AppleOAuthClient {
             throw e;
         } catch (Exception e) {
             throw new ApplicationException(AuthErrorCase.APPLE_ACCESS_TOKEN_INVALID, e);
-        }
-    }
-
-    private String exchangeAuthorizationCode(String authorizationCode) {
-        try {
-            WebClient webClient = webClientBuilder.build();
-            String clientSecret = generateClientSecret();
-
-            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-            formData.add("grant_type", "authorization_code");
-            formData.add("code", authorizationCode);
-            formData.add("client_id", properties.getClientId());
-            formData.add("client_secret", clientSecret);
-
-            JsonNode response = webClient.post()
-                    .uri(properties.getTokenUri())
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .body(BodyInserters.fromFormData(formData))
-                    .retrieve()
-                    .bodyToMono(JsonNode.class)
-                    .block();
-
-            if (response == null || !response.hasNonNull("refresh_token")) {
-                throw ApplicationException.from(AuthErrorCase.APPLE_TOKEN_EXCHANGE_FAILED);
-            }
-
-            return response.get("refresh_token").asText();
-        } catch (ApplicationException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new ApplicationException(AuthErrorCase.APPLE_TOKEN_EXCHANGE_FAILED, e);
         }
     }
 

--- a/src/main/java/com/wilo/server/auth/service/AuthService.java
+++ b/src/main/java/com/wilo/server/auth/service/AuthService.java
@@ -77,21 +77,31 @@ public class AuthService {
 
     @Transactional
     public TokenResponseDto loginWithAppleAndIssueToken(AppleLoginRequestDto request) {
-        AppleOAuthClient.AppleIdentityClaims claims = appleOAuthClient.verifyAccessToken(request.accessToken());
-        String appleSyntheticEmail = buildAppleEmailFromSubject(claims.subject());
+        AppleOAuthClient.AppleTokenExchangeResult exchangeResult =
+                appleOAuthClient.exchangeAuthorizationCode(request.authorizationCode());
+        AppleOAuthClient.AppleIdentityClaims exchangedClaims =
+                appleOAuthClient.verifyIdentityToken(exchangeResult.identityToken());
+        AppleOAuthClient.AppleIdentityClaims clientClaims =
+                appleOAuthClient.verifyIdentityToken(request.identityToken());
 
-        User user = userRepository.findByAuthProviderAndProviderUserId(AuthProvider.APPLE, claims.subject())
+        if (!exchangedClaims.subject().equals(clientClaims.subject())) {
+            throw ApplicationException.from(AuthErrorCase.APPLE_ACCESS_TOKEN_INVALID);
+        }
+
+        String appleSyntheticEmail = buildAppleEmailFromSubject(exchangedClaims.subject());
+
+        User user = userRepository.findByAuthProviderAndProviderUserId(AuthProvider.APPLE, exchangedClaims.subject())
                 .orElseGet(() -> userRepository.save(
                         User.builder()
                                 .email(appleSyntheticEmail)
                                 .password(passwordEncoder.encode(UUID.randomUUID().toString()))
-                                .nickname(buildUniqueAppleNickname(claims.subject()))
+                                .nickname(buildUniqueAppleNickname(exchangedClaims.subject()))
                                 .description(null)
                                 .profileImageUrl(null)
                                 .phoneNumber(null)
                                 .phoneVerified(false)
                                 .authProvider(AuthProvider.APPLE)
-                                .providerUserId(claims.subject())
+                                .providerUserId(exchangedClaims.subject())
                                 .build()
                 ));
 

--- a/src/test/java/com/wilo/server/domain/auth/AuthControllerTest.java
+++ b/src/test/java/com/wilo/server/domain/auth/AuthControllerTest.java
@@ -131,14 +131,23 @@ class AuthControllerTest {
 
     @Test
     void appleLogin_success() throws Exception {
-        when(appleOAuthClient.verifyAccessToken(anyString()))
+        when(appleOAuthClient.exchangeAuthorizationCode(anyString()))
+                .thenReturn(new AppleOAuthClient.AppleTokenExchangeResult(
+                        "apple-access-token",
+                        "apple-identity-token-from-apple",
+                        "apple-refresh-token"
+                ));
+        when(appleOAuthClient.verifyIdentityToken("apple-identity-token-from-apple"))
+                .thenReturn(new AppleOAuthClient.AppleIdentityClaims("apple-sub-123", "relay@example.com"));
+        when(appleOAuthClient.verifyIdentityToken("apple-identity-token-from-client"))
                 .thenReturn(new AppleOAuthClient.AppleIdentityClaims("apple-sub-123", "relay@example.com"));
 
         mockMvc.perform(post("/api/v1/auth/apple/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "accessToken": "dummy-token"
+                                  "authorizationCode": "dummy-auth-code",
+                                  "identityToken": "apple-identity-token-from-client"
                                 }
                                 """))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #54 

## 📝 작업 내용

> 애플 로그인 검증 로직 변경 요청에 따라 코드를 개선합니다

- 요청 필드명 변경 (AccessToken -> IdentityToken)
- AuthorizationCode 필드 및 검증 로직 추가

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 버그 수정

* Apple 로그인 인증 방식이 업데이트되었습니다. 보다 엄격한 인증 검증 절차가 적용되어 로그인 과정의 보안이 강화되었고, 사용자 계정 정보 보호 수준이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->